### PR TITLE
feat: add classes related to meetup scheduling and time policy

### DIFF
--- a/src/main/java/com/flab/mealmate/domain/meetup/api/MeetupApi.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/api/MeetupApi.java
@@ -1,0 +1,27 @@
+package com.flab.mealmate.domain.meetup.api;
+
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.flab.mealmate.domain.meetup.application.MeetupCreateService;
+import com.flab.mealmate.domain.meetup.dto.MeetupCreateRequest;
+import com.flab.mealmate.domain.meetup.dto.MeetupCreateResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/meetups")
+public class MeetupApi {
+
+	private final MeetupCreateService meetupCreateService;
+
+	@PostMapping
+	public MeetupCreateResponse create(@RequestBody @Validated MeetupCreateRequest request) {
+		return meetupCreateService.create(request);
+	}
+
+}

--- a/src/main/java/com/flab/mealmate/domain/meetup/application/MeetupCreateService.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/application/MeetupCreateService.java
@@ -1,0 +1,10 @@
+package com.flab.mealmate.domain.meetup.application;
+
+import com.flab.mealmate.domain.meetup.dto.MeetupCreateRequest;
+import com.flab.mealmate.domain.meetup.dto.MeetupCreateResponse;
+
+public interface MeetupCreateService {
+
+	MeetupCreateResponse create(MeetupCreateRequest request);
+
+}

--- a/src/main/java/com/flab/mealmate/domain/meetup/application/MeetupCreateServiceV1.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/application/MeetupCreateServiceV1.java
@@ -1,0 +1,48 @@
+package com.flab.mealmate.domain.meetup.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.flab.mealmate.domain.meetup.dao.MeetupParticipantRepository;
+import com.flab.mealmate.domain.meetup.dao.MeetupRepository;
+import com.flab.mealmate.domain.meetup.dto.MeetupCreateRequest;
+import com.flab.mealmate.domain.meetup.dto.MeetupCreateResponse;
+import com.flab.mealmate.domain.meetup.entity.Meetup;
+import com.flab.mealmate.domain.meetup.entity.MeetupParticipant;
+import com.flab.mealmate.domain.meetup.mapper.MeetupCreateMapper;
+import com.flab.mealmate.domain.meetup.policy.MeetupTimePolicy;
+import com.flab.mealmate.global.common.TimeProvider;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MeetupCreateServiceV1 implements MeetupCreateService {
+
+	private final MeetupRepository meetupRepository;
+
+	private final MeetupCreateMapper meetupCreateMapper;
+
+	private final MeetupTimePolicy meetupTimePolicy;
+
+	private final TimeProvider timeProvider;
+
+	private final MeetupParticipantRepository meetupParticipantRepository;
+
+	@Override
+	public MeetupCreateResponse create(MeetupCreateRequest request) {
+		var meetUp = meetupCreateMapper.toEntity(request, timeProvider.now(), meetupTimePolicy);
+
+		meetupRepository.save(meetUp);
+		addHostAsParticipant(meetUp);
+
+		return meetupCreateMapper.toResponse(meetUp);
+	}
+
+	// 호스트 자동 추가 메서드
+	private void addHostAsParticipant(Meetup meetup) {
+		meetupParticipantRepository.save(MeetupParticipant.createHostParticipant(meetup));
+	}
+
+}

--- a/src/main/java/com/flab/mealmate/domain/meetup/dao/MeetupParticipantRepository.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/dao/MeetupParticipantRepository.java
@@ -1,0 +1,8 @@
+package com.flab.mealmate.domain.meetup.dao;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.flab.mealmate.domain.meetup.entity.MeetupParticipant;
+
+public interface MeetupParticipantRepository extends JpaRepository<MeetupParticipant, Long> {
+}

--- a/src/main/java/com/flab/mealmate/domain/meetup/dto/MeetupCreateRequest.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/dto/MeetupCreateRequest.java
@@ -1,0 +1,56 @@
+package com.flab.mealmate.domain.meetup.dto;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.flab.mealmate.domain.meetup.entity.ParticipationType;
+import com.flab.mealmate.global.error.exception.CustomIllegalArgumentException;
+import com.flab.mealmate.global.error.exception.ErrorCode;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class MeetupCreateRequest {
+
+	@NotEmpty
+	private final String title;
+
+	@NotEmpty
+	private final String content;
+
+	@NotNull
+	private final ParticipationType participationType;
+
+	@NotNull
+	@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+	private final LocalDateTime startDateTime;
+
+	@NotNull
+	@Min(value = 2) @Max(value = 200)
+	private final int minParticipants;
+
+	@NotNull
+	@Min(value = 2)  @Max(value = 200)
+	private final int maxParticipants;
+
+	public MeetupCreateRequest(String title, String content, ParticipationType participationType,
+		LocalDateTime startDateTime, int minParticipants, int maxParticipants) {
+		this.title = title;
+		this.content = content;
+		this.participationType = participationType;
+		this.startDateTime = startDateTime;
+		this.minParticipants = minParticipants;
+		this.maxParticipants = maxParticipants;
+		validateParticipants();
+	}
+
+	private void validateParticipants() {
+		if (this.maxParticipants < this.minParticipants) {
+			throw new CustomIllegalArgumentException(ErrorCode.ERR_MEETUP_002);
+		}
+	}
+}

--- a/src/main/java/com/flab/mealmate/domain/meetup/dto/MeetupCreateResponse.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/dto/MeetupCreateResponse.java
@@ -1,0 +1,13 @@
+package com.flab.mealmate.domain.meetup.dto;
+
+import lombok.Getter;
+
+@Getter
+public class MeetupCreateResponse {
+
+	private final String id;
+
+	public MeetupCreateResponse(String id) {
+		this.id = id;
+	}
+}

--- a/src/main/java/com/flab/mealmate/domain/meetup/entity/MeetupParticipant.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/entity/MeetupParticipant.java
@@ -1,0 +1,58 @@
+package com.flab.mealmate.domain.meetup.entity;
+
+import org.hibernate.annotations.Comment;
+
+import com.flab.mealmate.domain.model.BaseEntity;
+
+import io.hypersistence.utils.hibernate.id.Tsid;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "meetup_participant")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MeetupParticipant extends BaseEntity {
+
+	@Id @Tsid
+	private Long id;
+
+	@ManyToOne
+	@JoinColumn(name = "meetup_id")
+	private Meetup meetup;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	@Comment("참여자의 상태")
+	private ParticipationStatus participationStatus;
+
+	@Comment("참여 신청 시 작성하는 내용")
+	private String applicationMessage;
+
+	private MeetupParticipant(Meetup meetup, ParticipationStatus participationStatus, String applicationMessage) {
+		this.meetup = meetup;
+		this.participationStatus = participationStatus;
+		this.applicationMessage = applicationMessage;
+	}
+
+	public static MeetupParticipant createHostParticipant(Meetup meetup) {
+		return new MeetupParticipant(meetup, ParticipationStatus.APPROVED, null);
+	}
+
+	public static MeetupParticipant createPendingParticipant(Meetup meetup, String applicationMessage) {
+		return new MeetupParticipant(meetup, ParticipationStatus.PENDING, applicationMessage);
+	}
+
+	public static MeetupParticipant createApprovedParticipant(Meetup meetup) {
+		return new MeetupParticipant(meetup, ParticipationStatus.APPROVED, null);
+	}
+}

--- a/src/main/java/com/flab/mealmate/domain/meetup/entity/ParticipationStatus.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/entity/ParticipationStatus.java
@@ -1,0 +1,19 @@
+package com.flab.mealmate.domain.meetup.entity;
+
+public enum ParticipationStatus {
+
+	PENDING("대기 중"),
+	APPROVED("승인"),
+	REJECTED("거절")
+	;
+
+	private String description;
+
+	ParticipationStatus(String description) {
+		this.description = description;
+	}
+
+	private String description() {
+		return  this.description;
+	}
+}

--- a/src/main/java/com/flab/mealmate/domain/meetup/mapper/MeetupCreateMapper.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/mapper/MeetupCreateMapper.java
@@ -1,0 +1,34 @@
+package com.flab.mealmate.domain.meetup.mapper;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+
+import com.flab.mealmate.domain.meetup.dto.MeetupCreateRequest;
+import com.flab.mealmate.domain.meetup.dto.MeetupCreateResponse;
+import com.flab.mealmate.domain.meetup.entity.Meetup;
+import com.flab.mealmate.domain.meetup.entity.MeetupSchedule;
+import com.flab.mealmate.domain.meetup.policy.MeetupTimePolicy;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MeetupCreateMapper {
+
+	public Meetup toEntity(MeetupCreateRequest request, LocalDateTime now, MeetupTimePolicy policy) {
+		var schedule = MeetupSchedule.create(request.getStartDateTime(), now, policy);
+		return new Meetup(
+			request.getTitle(),
+			request.getContent(),
+			schedule,
+			request.getParticipationType(),
+			request.getMinParticipants(),
+			request.getMaxParticipants()
+		);
+	}
+
+	public MeetupCreateResponse toResponse(Meetup meetup) {
+		return new MeetupCreateResponse(String.valueOf(meetup.getId()));
+	}
+}

--- a/src/main/java/com/flab/mealmate/global/common/SystemTimeProvider.java
+++ b/src/main/java/com/flab/mealmate/global/common/SystemTimeProvider.java
@@ -1,0 +1,15 @@
+package com.flab.mealmate.global.common;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class SystemTimeProvider implements TimeProvider {
+
+	@Override
+	public LocalDateTime now() {
+		return LocalDateTime.now();
+	}
+
+}

--- a/src/main/java/com/flab/mealmate/global/common/TimeProvider.java
+++ b/src/main/java/com/flab/mealmate/global/common/TimeProvider.java
@@ -1,0 +1,7 @@
+package com.flab.mealmate.global.common;
+
+import java.time.LocalDateTime;
+
+public interface TimeProvider {
+	LocalDateTime now();
+}

--- a/src/main/java/com/flab/mealmate/global/config/datasource/DataSourceConfig.java
+++ b/src/main/java/com/flab/mealmate/global/config/datasource/DataSourceConfig.java
@@ -20,7 +20,7 @@ import lombok.extern.slf4j.Slf4j;
  * 트랜잭션 종류에 따른 Datasource 분리를 위한 설정
  */
 @Slf4j
-@Profile({"!local"})
+@Profile({"prd"})
 @Configuration
 public class DataSourceConfig {
 

--- a/src/main/java/com/flab/mealmate/global/config/datasource/LocalDataSourceConfig.java
+++ b/src/main/java/com/flab/mealmate/global/config/datasource/LocalDataSourceConfig.java
@@ -1,11 +1,7 @@
 package com.flab.mealmate.global.config.datasource;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import javax.sql.DataSource;
 
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.context.annotation.Bean;
@@ -18,7 +14,7 @@ import com.zaxxer.hikari.HikariDataSource;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-@Profile("local")
+@Profile({"local", "test"})
 @Configuration
 public class LocalDataSourceConfig {
 
@@ -30,4 +26,5 @@ public class LocalDataSourceConfig {
 			.type(HikariDataSource.class)
 			.build();
 	}
+
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,7 +13,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: meal_mate_local
     password: meal_mate_local
-    jdbcUrl: jdbc:mysql://localhost:3306/meal_mate_db?useUnicode=yes&useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=utf8&allowPublicKeyRetrieval=true&zeroDateTimeBehavior=convertToNull&sendFractionalSeconds=false
+    jdbc-url: jdbc:mysql://localhost:3306/meal_mate_db?useUnicode=yes&useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=utf8&allowPublicKeyRetrieval=true&zeroDateTimeBehavior=convertToNull&sendFractionalSeconds=false
 
   jackson:
     time-zone: Asia/Seoul

--- a/src/test/java/com/flab/mealmate/domain/meetup/api/MeetupApiTest.java
+++ b/src/test/java/com/flab/mealmate/domain/meetup/api/MeetupApiTest.java
@@ -1,0 +1,87 @@
+package com.flab.mealmate.domain.meetup.api;
+
+import static com.flab.mealmate.global.ApiDocumentation.*;
+import static com.flab.mealmate.global.util.JsonUtils.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.flab.mealmate.domain.meetup.application.MeetupCreateService;
+import com.flab.mealmate.domain.meetup.dto.MeetupCreateRequest;
+import com.flab.mealmate.domain.meetup.dto.MeetupCreateResponse;
+import com.flab.mealmate.domain.meetup.entity.ParticipationType;
+import com.flab.mealmate.global.ApiDocumentation;
+
+
+@WithMockUser
+@AutoConfigureRestDocs
+@WebMvcTest(MeetupApi.class)
+class MeetupApiTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private MeetupCreateService meetupCreateService;
+
+	private final String TAG = "meetup";
+
+	@Test
+	@DisplayName("모임 생성 API")
+	void createMeetup() throws Exception {
+		var request = new MeetupCreateRequest(
+			"신촌에서 같이 밥먹을 사람",
+			"샤브샤브 먹고싶어요.",
+			ParticipationType.AUTO,
+			LocalDateTime.of(2026, 1, 1, 12, 0, 0, 0),
+			3,
+			5
+		);
+
+		var response = new MeetupCreateResponse("1");
+
+		// Mocking the service call
+		given(meetupCreateService.create(any(MeetupCreateRequest.class))).willReturn(response);
+
+		// Perform the API request
+		ResultActions actions = mockMvc.perform(post("/meetups")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request))
+				.with(csrf().asHeader()))
+			.andExpect(status().isOk());
+
+		actions.andDo(ApiDocumentation.builder()
+				.tag(TAG)
+				.description("모임 생성 API")
+				.requestFields(
+					field("title", STRING, "모임 제목"),
+					field("content", STRING, "모임 내용"),
+					field("participationType", STRING, "참여 유형" ),
+					field("startDateTime", STRING, "시작 시간"),
+					field("minParticipants", NUMBER, "최소 인원"),
+					field("maxParticipants", NUMBER, "최대 인원")
+				)
+				.responseFields(
+					field("id", STRING, "생성된 모임 ID")
+				)
+				.build())
+			.andDo(print());
+	}
+
+}

--- a/src/test/java/com/flab/mealmate/domain/meetup/application/MeetupCreateServiceV1Test.java
+++ b/src/test/java/com/flab/mealmate/domain/meetup/application/MeetupCreateServiceV1Test.java
@@ -1,0 +1,90 @@
+package com.flab.mealmate.domain.meetup.application;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.flab.mealmate.domain.meetup.dao.MeetupParticipantRepository;
+import com.flab.mealmate.domain.meetup.dao.MeetupRepository;
+import com.flab.mealmate.domain.meetup.dto.MeetupCreateRequest;
+import com.flab.mealmate.domain.meetup.dto.MeetupCreateResponse;
+import com.flab.mealmate.domain.meetup.entity.Meetup;
+import com.flab.mealmate.domain.meetup.entity.MeetupParticipant;
+import com.flab.mealmate.domain.meetup.entity.MeetupSchedule;
+import com.flab.mealmate.domain.meetup.entity.ParticipationType;
+import com.flab.mealmate.domain.meetup.mapper.MeetupCreateMapper;
+import com.flab.mealmate.domain.meetup.policy.MeetupTimePolicy;
+import com.flab.mealmate.global.common.TimeProvider;
+
+@ExtendWith(MockitoExtension.class)
+class MeetupCreateServiceV1Test {
+
+	@Mock
+	private MeetupRepository meetupRepository;
+
+	@Mock
+	private MeetupCreateMapper meetupCreateMapper;
+
+	@Mock
+	private MeetupTimePolicy meetupTimePolicy;
+
+	@Mock
+	private TimeProvider timeProvider;
+
+	@Mock
+	private MeetupParticipantRepository meetupParticipantRepository;
+
+	@InjectMocks
+	private MeetupCreateServiceV1 meetupCreateService;
+
+	private MeetupCreateRequest request;
+
+	@BeforeEach
+	void setUp() {
+		var now = LocalDateTime.of(2026, 1, 1, 12, 0, 0, 0);
+		given(timeProvider.now()).willReturn(now);
+
+		request = new MeetupCreateRequest(
+			"신촌에서 같이 밥먹을 사람",
+			"샤브샤브 먹고싶어요.",
+			ParticipationType.AUTO,
+			timeProvider.now(),
+			3,
+			5
+		);
+	}
+
+	@Test
+	void create() {
+		var schedule = MeetupSchedule.create(request.getStartDateTime(),request.getStartDateTime(), meetupTimePolicy);
+		var meetup = new Meetup("신촌에서 같이 밥먹을 사람", "샤브샤브 먹고싶어요.", schedule, ParticipationType.AUTO, 3, 5);
+		var response = new MeetupCreateResponse("1");
+
+		given(meetupCreateMapper.toEntity(
+			any(MeetupCreateRequest.class),
+			any(LocalDateTime.class),
+			any(MeetupTimePolicy.class)
+		)).willReturn(meetup);
+		given(meetupRepository.save(any(Meetup.class))).willReturn(meetup);
+		given(meetupCreateMapper.toResponse(any(Meetup.class))).willReturn(response);
+
+		MeetupCreateResponse result = meetupCreateService.create(request);
+
+		assertNotNull(result);
+		assertEquals("1", result.getId());
+
+		verify(meetupCreateMapper, times(1)).toEntity(request, timeProvider.now(), meetupTimePolicy);
+		verify(meetupRepository, times(1)).save(meetup);
+		verify(meetupParticipantRepository, times(1)).save(any(MeetupParticipant.class));
+		verify(meetupCreateMapper, times(1)).toResponse(meetup);
+	}
+
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,7 +1,16 @@
+server:
+  port: 8081
+
+service:
+  environment: test
+
 spring:
+  application:
+    name: meal-mate
+
   datasource:
+    jdbc-url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;
     driver-class-name: org.h2.Driver
-    jdbcUrl: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MYSQL
     username: sa
     password: ""
 


### PR DESCRIPTION
## ✅ 개요
- 소셜링(밥친구 모집) 생성 API 및 서비스 로직 추가
---

## ✅ 주요 변경 사항

###  📌도메인 추가 
- `MeetupParticipant`,엔티티 클래스 작성
- 참여자 상태 `Enum` 정의
  - `ParticipationStatus' : PENDING("대기 중") / APPROVED("승인") / REJECTED("거절")

### 📌 API 및 서비스 로직 추가 
- `MeetupApi`, `MeetupCreateService`

### 📌 테스트 코드 작성
- `MeetupApiTest`, `MeetupCreateServiceV1Test`
---

## ✅ 고민이었던 점
- `Meetup` 참가자에 호스트를 자동으로 추가해야 하는 로직을 어디에서 처리할 것인지 고민
    - `Meetup` 클래스에서 연관 관계를 맺고 생성: `Meetup` 엔티티가 `MeetupParticipant` 생성의 책임을 맡는다.
        - `Meetup` 클래스가 너무 많은 책임을 가지게 되므로, 객체의 책임이 과도해질 수 있다고 생각합니다.  
    - 서비스에서 호스트 참가자 추가: 서비스 레이어에서 호스트 참가자를 추가하는 로직을 처리한다.
        - 호스트 처리 로직 누락 가능성이 높아지는게 아닌가 걱정됩니다.
- `MeetupCreateServiceV1Test` 테스트 범위
     - `Meetup` 생성시 발생할수 있는 에러는 도메인 테스트를 작성하고, 서비스 로직 테스트에서는 상호작용 검증만을 진행했습니다. 올바른 의사결정인지 궁금합니다.

## 📎 관련 이슈
- #7
