### PR TITLE
refactor: clean up test code imports, method names, and exception loging

### DIFF
--- a/src/main/java/com/flab/mealmate/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/flab/mealmate/global/error/GlobalExceptionHandler.java
@@ -42,7 +42,7 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(IllegalArgumentException.class)
 	protected ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
-		log.debug(null, e);
+		log.debug("Invalid argument encountered: {}", e.getMessage(), e);
 		var errorMessage = StringUtils.hasText(e.getMessage()) ? e.getMessage() : ERR_INVALID_TYPE_VALUE.getValue();
 		var response = ErrorResponse.errorMessageBuilder()
 				.errorCode(ERR_INVALID_TYPE_VALUE)
@@ -53,8 +53,8 @@ public class GlobalExceptionHandler {
 	}
 
 	@ExceptionHandler(CustomIllegalArgumentException.class)
-	protected ResponseEntity<ErrorResponse> handleIllegalArgumentException(CustomIllegalArgumentException e) {
-		log.debug(null, e);
+	protected ResponseEntity<ErrorResponse> handleCustomIllegalArgumentException(CustomIllegalArgumentException e) {
+		log.debug("Custom illegal argument exception occurred: {}", e.getMessage(), e);
 		var response = ErrorResponse.errorMessageBuilder()
 			.errorCode(e.getErrorCode())
 			.errorMessage(e.getMessage())
@@ -66,7 +66,7 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(BusinessException.class)
 	protected ResponseEntity<ErrorResponse> handleBusinessException(final BusinessException e) {
-		log.debug(null, e);
+		log.debug("Business logic exception: {}", e.getMessage(), e);
 		String errorMessage = messageSource.getMessage(e.getMessage(), e.getStringArgList(), LocaleContextHolder.getLocale());
 
 		var errorCode = e.getErrorCode();
@@ -80,7 +80,7 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(FeignClientException.class)
 	protected ResponseEntity<ErrorResponse> handleFeignClientException(FeignClientException e) {
-		log.error(null, e);
+		log.error("Exception during Feign client call: {}", e.getMessage(), e);
 
 		var response = e.getErrorResponse();
 
@@ -90,7 +90,7 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler({MissingServletRequestParameterException.class})
 	public ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(
 		final MissingServletRequestParameterException e) {
-		log.debug(null, e);
+		log.debug("Missing request parameter: {}", e.getMessage(), e);
 
 		var errorMessage = StringUtils.hasText(e.getMessage()) ? e.getMessage() : ERR_INVALID_INPUT_VALUE.getValue();
 		var response = ErrorResponse.errorMessageBuilder()
@@ -108,7 +108,7 @@ public class GlobalExceptionHandler {
 	 */
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
-		log.debug(null, e);
+		log.debug("Validation failed for request body: {}", e.getMessage(), e);
 
 		var errorMessage = StringUtils.hasText(e.getMessage()) ? e.getMessage() : ERR_INVALID_INPUT_VALUE.getValue();
 		var response = ErrorResponse.of(ERR_INVALID_INPUT_VALUE, errorMessage, e.getBindingResult());
@@ -123,7 +123,7 @@ public class GlobalExceptionHandler {
 	 */
 	@ExceptionHandler(BindException.class)
 	protected ResponseEntity<ErrorResponse> handleBindException(BindException e) {
-		log.debug(null, e);
+		log.debug("Binding error for model attributes: {}", e.getMessage(), e);
 
 		var response = ErrorResponse.of(
 			ERR_INVALID_INPUT_VALUE,
@@ -140,7 +140,7 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
 	protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
 		MethodArgumentTypeMismatchException e) {
-		log.debug(null, e);
+		log.debug("Type mismatch for request parameter: {}", e.getMessage(), e);
 
 		final List<ErrorResponse.FieldError> errors = ErrorResponse.FieldError.of(e.getName(), e.getValue().toString(), e.getErrorCode());
 
@@ -158,7 +158,7 @@ public class GlobalExceptionHandler {
 	 */
 	@ExceptionHandler({MissingServletRequestPartException.class, HttpMediaTypeNotSupportedException.class})
 	protected ResponseEntity<ErrorResponse> handleServletException(ServletException e) {
-		log.debug(null, e);
+		log.debug("Multipart request error or unsupported media type: {}", e.getMessage(), e);
 
 		var errorMessage = StringUtils.hasText(e.getMessage()) ? e.getMessage() : ERR_INVALID_INPUT_VALUE.getValue();
 		var response = ErrorResponse.errorMessageBuilder()
@@ -174,7 +174,7 @@ public class GlobalExceptionHandler {
 	 */
 	@ExceptionHandler(HttpMessageNotReadableException.class)
 	protected ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
-		log.debug(null, e);
+		log.debug("Failed to parse HTTP request body: {}", e.getMessage(), e);
 
 		if (e.getCause().getCause() instanceof BusinessException) {
 			BusinessException businessException = (BusinessException) e.getCause();
@@ -205,7 +205,7 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
 	protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(
 		HttpRequestMethodNotSupportedException e) {
-		log.debug(null, e);
+		log.debug("Unsupported HTTP method used: {}", e.getMessage(), e);
 
 		var errorMessage = StringUtils.hasText(e.getMessage()) ? e.getMessage()
 			: messageSource.getMessage(ERR_METHOD_NOT_ALLOWED.getValue(), null,
@@ -224,7 +224,7 @@ public class GlobalExceptionHandler {
 	 */
 	@ExceptionHandler(Exception.class)
 	protected ResponseEntity<ErrorResponse> handleException(Exception e) {
-		log.error(null, e);
+		log.error("Unhandled server error: {}", e.getMessage(), e);
 
 		var errorMessage = StringUtils.hasText(e.getMessage()) ? e.getMessage()
 			: messageSource.getMessage(ErrorCode.ERR_INTERNAL_SERVER_ERROR.getValue(), null,
@@ -243,7 +243,7 @@ public class GlobalExceptionHandler {
 	 */
 	@ExceptionHandler({DataBaseException.class})
 	public ResponseEntity<ErrorResponse> handleDataBaseException(final DataBaseException e) {
-		log.error(null, e);
+		log.error("Database operation failed: {}", e.getMessage(), e);
 
 		String message = messageSource.getMessage(ERR_DB.getValue(), null, LocaleContextHolder.getLocale());
 		var response = ErrorResponse.errorMessageBuilder()

--- a/src/test/java/com/flab/mealmate/domain/meetup/api/MeetupApiTest.java
+++ b/src/test/java/com/flab/mealmate/domain/meetup/api/MeetupApiTest.java
@@ -1,13 +1,15 @@
 package com.flab.mealmate.domain.meetup.api;
 
-import static com.flab.mealmate.global.ApiDocumentation.*;
-import static com.flab.mealmate.global.util.JsonUtils.*;
-import static org.mockito.BDDMockito.*;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
-import static org.springframework.restdocs.payload.JsonFieldType.*;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static com.flab.mealmate.global.ApiDocumentation.field;
+import static com.flab.mealmate.global.util.JsonUtils.objectMapper;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.LocalDateTime;
 
@@ -27,7 +29,6 @@ import com.flab.mealmate.domain.meetup.dto.MeetupCreateRequest;
 import com.flab.mealmate.domain.meetup.dto.MeetupCreateResponse;
 import com.flab.mealmate.domain.meetup.entity.ParticipationType;
 import com.flab.mealmate.global.ApiDocumentation;
-
 
 @WithMockUser
 @AutoConfigureRestDocs

--- a/src/test/java/com/flab/mealmate/domain/meetup/application/MeetupCreateServiceV1Test.java
+++ b/src/test/java/com/flab/mealmate/domain/meetup/application/MeetupCreateServiceV1Test.java
@@ -1,7 +1,12 @@
 package com.flab.mealmate.domain.meetup.application;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.BDDMockito.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.time.LocalDateTime;
 

--- a/src/test/java/com/flab/mealmate/domain/meetup/entity/MeetupScheduleTest.java
+++ b/src/test/java/com/flab/mealmate/domain/meetup/entity/MeetupScheduleTest.java
@@ -1,6 +1,9 @@
 package com.flab.mealmate.domain.meetup.entity;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 import com.flab.mealmate.domain.meetup.policy.MeetupTimePolicy;
@@ -12,7 +15,7 @@ class MeetupScheduleTest {
 	private final MeetupTimePolicy policy = new MeetupTimePolicy();
 
 	@Test
-	void creates_meetup_schedule_successfully() {
+	void createsMeetupScheduleSuccessfully() {
 		LocalDateTime start = LocalDateTime.of(2026,1,1,12,0);
 		LocalDateTime reference = start.minusHours(policy.minHoursBeforeStart());
 
@@ -23,7 +26,7 @@ class MeetupScheduleTest {
 	}
 
 	@Test
-	void throws_exception_when_start_time_is_too_early() {
+	void throwsExceptionWhenStartTimeIsTooEarly() {
 		LocalDateTime start = LocalDateTime.of(2026,1,1,12,0);
 		LocalDateTime reference = start.minusHours(policy.minHoursBeforeStart()).plusMinutes(10);
 
@@ -35,7 +38,7 @@ class MeetupScheduleTest {
 	}
 
 	@Test
-	void calculates_recruitment_deadline_based_on_policy() {
+	void calculatesRecruitmentDeadlineBasedOnPolicy() {
 		LocalDateTime start = LocalDateTime.of(2026,1,1,12,0);
 		LocalDateTime reference = start.minusHours(policy.minHoursBeforeStart());
 		LocalDateTime deadline = start.minusHours(policy.minHoursBeforeRecruitmentDeadline());

--- a/src/test/java/com/flab/mealmate/domain/meetup/entity/MeetupTest.java
+++ b/src/test/java/com/flab/mealmate/domain/meetup/entity/MeetupTest.java
@@ -12,7 +12,7 @@ import com.flab.mealmate.global.error.exception.ErrorCode;
 class MeetupTest {
 
 	@Test
-	void creates_meetup_successfully() {
+	void createsMeetupSuccessfully() {
 		var expectedRecruitmentStatus = RecruitmentStatus.OPEN;
 		var expectedProgressStatus = ProgressStatus.SCHEDULED;
 
@@ -25,7 +25,7 @@ class MeetupTest {
 	}
 
 	@Test
-	void hrows_exception_when_min_participants_exceeds_max() {
+	void throwsExceptionWhenMinParticipantsExceedsMax() {
 		var schedule = new MeetupSchedule();
 		var expected = ErrorCode.ERR_MEETUP_002;
 		BusinessException e = assertThrows(BusinessException.class, () -> {


### PR DESCRIPTION
## ✅ 주요 변경 사항
- [x] test class static import 정리
    - 와일드카드(*) import를 제거하고, 필요한 static 멤버를 명시적으로 import하도록 변경했습니다.
- [X] 테스트 메서드 이름 변경
   - 기존의 스네이크 케이스를 제거하고, 카멜 케이스로 통일하여 가독성을 높였습니다.
- [X] 예외 발생 시 로깅 메시지 개선
    - e.getMessage()를 추가하여, 기존에 null로 출력되던 예외 메시지를 명확하게 로깅하도록 수정했습니다.