### PR TITLE
feat: add meetup custom repository with Querydsl

### DIFF
--- a/src/main/java/com/flab/mealmate/domain/meetup/dao/CustomMeetupRepository.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/dao/CustomMeetupRepository.java
@@ -1,0 +1,12 @@
+package com.flab.mealmate.domain.meetup.dao;
+
+import org.springframework.data.domain.Page;
+
+import com.flab.mealmate.domain.meetup.dto.MeetupSearchCriteria;
+import com.flab.mealmate.domain.meetup.dto.MeetupSearchResult;
+
+public interface CustomMeetupRepository {
+
+	Page<MeetupSearchResult> page(MeetupSearchCriteria criteria);
+
+}

--- a/src/main/java/com/flab/mealmate/domain/meetup/dao/MeetupQuerydslRepository.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/dao/MeetupQuerydslRepository.java
@@ -1,0 +1,75 @@
+package com.flab.mealmate.domain.meetup.dao;
+
+import static com.flab.mealmate.domain.meetup.entity.QMeetup.*;
+import static com.flab.mealmate.domain.meetup.entity.QMeetupParticipant.*;
+import static com.flab.mealmate.global.util.querydsl.BooleanExpressionUtils.*;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import com.flab.mealmate.domain.meetup.dto.MeetupSearchCriteria;
+import com.flab.mealmate.domain.meetup.dto.MeetupSearchResult;
+import com.flab.mealmate.domain.meetup.dto.QMeetupSearchResult;
+import com.flab.mealmate.domain.meetup.entity.ProgressStatus;
+import com.flab.mealmate.global.util.querydsl.FullTextSearchUtils;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class MeetupQuerydslRepository implements CustomMeetupRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public Page<MeetupSearchResult> page(MeetupSearchCriteria criteria) {
+		var content = queryFactory
+			.select(new QMeetupSearchResult(
+				meetup.id,
+				meetup.title,
+				meetup.content,
+				meetup.schedule.startDatetime,
+				meetup.participationType,
+				meetup.recruitmentStatus,
+				meetupParticipant.id.count()
+			))
+			.from(meetup)
+			.leftJoin(meetupParticipant)
+			.on(meetupParticipant.meetup.id.eq(meetup.id))
+			.where(
+				eqProgressStatus(criteria.getProgressStatus()),
+				ltId(criteria.getCursorId()),
+				searchFullText(criteria.getKeyword())
+			)
+			.orderBy(meetup.id.desc())
+			.limit(criteria.getPageSize())
+			.fetch();
+
+		var countQuery = queryFactory
+			.select(meetup.id.count())
+			.from(meetup)
+			.where(
+				eqProgressStatus(criteria.getProgressStatus()),
+				ltId(criteria.getCursorId()),
+				searchFullText(criteria.getKeyword())
+			);
+
+		return PageableExecutionUtils.getPage(content, criteria.getPageable(), countQuery::fetchOne);
+	}
+
+	private Predicate ltId(Long cursorId) {
+		return nullSafeBuilder(() -> meetup.id.lt(cursorId));
+	}
+
+	private Predicate searchFullText(String keyword) {
+		return FullTextSearchUtils.fullTextSearchBuilder(meetup.searchText, keyword);
+	}
+
+	private Predicate eqProgressStatus(ProgressStatus progressStatus) {
+		return nullSafeBuilder(() -> meetup.progressStatus.eq(progressStatus));
+	}
+
+}

--- a/src/main/java/com/flab/mealmate/domain/meetup/dto/MeetupSearchCriteria.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/dto/MeetupSearchCriteria.java
@@ -1,0 +1,28 @@
+package com.flab.mealmate.domain.meetup.dto;
+
+import static com.flab.mealmate.domain.meetup.entity.ProgressStatus.*;
+
+import org.springframework.data.domain.Pageable;
+
+import com.flab.mealmate.domain.meetup.entity.ProgressStatus;
+
+import lombok.Getter;
+
+@Getter
+public class MeetupSearchCriteria {
+
+	private final Pageable pageable;
+	private final String keyword;
+	private final Long cursorId;
+	private final ProgressStatus progressStatus = SCHEDULED;
+
+	public MeetupSearchCriteria(Pageable pageable, String keyword, Long cursorId) {
+		this.pageable = pageable;
+		this.keyword = keyword;
+		this.cursorId = cursorId;
+	}
+
+	public int getPageSize() {
+		return this.pageable.getPageSize();
+	}
+}

--- a/src/main/java/com/flab/mealmate/domain/meetup/dto/MeetupSearchResult.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/dto/MeetupSearchResult.java
@@ -1,0 +1,33 @@
+package com.flab.mealmate.domain.meetup.dto;
+
+import java.time.LocalDateTime;
+
+import com.flab.mealmate.domain.meetup.entity.ParticipationType;
+import com.flab.mealmate.domain.meetup.entity.RecruitmentStatus;
+import com.querydsl.core.annotations.QueryProjection;
+
+import lombok.Getter;
+
+@Getter
+public class MeetupSearchResult {
+
+	private final Long id;
+	private final String title;
+	private final String description;
+	private final LocalDateTime startDateTime;
+	private final ParticipationType participationType;
+	private final RecruitmentStatus recruitmentStatus;
+	private final long participants;
+
+	@QueryProjection
+	public MeetupSearchResult(Long id, String title, String description, LocalDateTime startDateTime,
+		ParticipationType participationType, RecruitmentStatus recruitmentStatus, long participants) {
+		this.id = id;
+		this.title = title;
+		this.description = description;
+		this.startDateTime = startDateTime;
+		this.participationType = participationType;
+		this.recruitmentStatus = recruitmentStatus;
+		this.participants = participants;
+	}
+}

--- a/src/main/java/com/flab/mealmate/global/util/querydsl/BooleanExpressionUtils.java
+++ b/src/main/java/com/flab/mealmate/global/util/querydsl/BooleanExpressionUtils.java
@@ -1,0 +1,17 @@
+package com.flab.mealmate.global.util.querydsl;
+
+import java.util.function.Supplier;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+
+public class BooleanExpressionUtils {
+
+	public static BooleanBuilder nullSafeBuilder(Supplier<BooleanExpression> f) {
+		try {
+			return new BooleanBuilder(f.get());
+		} catch (IllegalArgumentException | NullPointerException e) {
+			return new BooleanBuilder();
+		}
+	}
+}

--- a/src/main/java/com/flab/mealmate/global/util/querydsl/FullTextSearchUtils.java
+++ b/src/main/java/com/flab/mealmate/global/util/querydsl/FullTextSearchUtils.java
@@ -1,0 +1,29 @@
+package com.flab.mealmate.global.util.querydsl;
+
+import org.springframework.util.StringUtils;
+
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberTemplate;
+import com.querydsl.core.types.dsl.StringPath;
+
+public class FullTextSearchUtils {
+
+	private static final String MATCH_QUERY_TEMPLATE = "match({0}) against ({1} in boolean mode)";
+	private static final double MINIMUM_MATCH_SCORE = 0.0;
+
+	public static Predicate fullTextSearchBuilder(StringPath fullTextColumn, String keyword) {
+		if (!StringUtils.hasText(keyword)) {
+			return null; // 키워드가 없으면 null 반환
+		}
+
+		NumberTemplate<Double> score = Expressions.numberTemplate(
+			Double.class,
+			MATCH_QUERY_TEMPLATE,
+			fullTextColumn,
+			Expressions.constant(keyword)
+		);
+
+		return score.gt(MINIMUM_MATCH_SCORE);
+	}
+}


### PR DESCRIPTION
## ✅ 개요
QueryDSL을 사용해 진행 예정 중인 meetup 리스트를 조회하는 커스텀 Repository를 구현했습니다.

## ✅ 주요 변경 사항
- [x] QueryDSL용 BooleanExpression 및 FullTextSearch 유틸 추가
    - 동적 쿼리 생성 시 nullSafe 처리를 위한 nullSafeBuilder 메서드를 추가했습니다.
    - Full-text 검색을 위한 fullTextSearchBuilder 메서드를 추가했습니다.
- [X] Meetup 도메인 검색 기능 추가
    - 진행 중인 meetup 리스트 조회를 위한 MeetupQuerydslRepository.page 메서드를 구현했습니다.
    - 검색 조건: 키워드, 진행 상태, 커서 기반 페이지네이션 지원

## 📎 관련 이슈
- #7