### PR TITLE
feat: implement MeetupSearchMapper with DTOs and unit tests

### DIFF
--- a/src/main/java/com/flab/mealmate/domain/meetup/dto/MeetupSearchRequest.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/dto/MeetupSearchRequest.java
@@ -1,0 +1,25 @@
+package com.flab.mealmate.domain.meetup.dto;
+
+import static com.flab.mealmate.domain.meetup.entity.ProgressStatus.SCHEDULED;
+
+import com.flab.mealmate.domain.meetup.entity.ProgressStatus;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class MeetupSearchRequest {
+
+	private final ProgressStatus progressStatus = SCHEDULED;
+	private final String keyword;
+	@NotNull @Max(value = 100)
+	private final int size;
+	private final Long cursorId;
+
+	public MeetupSearchRequest(String keyword, int size, Long cursorId) {
+		this.keyword = keyword;
+		this.size = size;
+		this.cursorId = cursorId;
+	}
+}

--- a/src/main/java/com/flab/mealmate/domain/meetup/dto/MeetupSearchResponse.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/dto/MeetupSearchResponse.java
@@ -1,0 +1,18 @@
+package com.flab.mealmate.domain.meetup.dto;
+
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class MeetupSearchResponse {
+	private final Long totalCount;
+	private final String  cursorId;
+	private final List<MeetupSummary> meetups;
+
+	public MeetupSearchResponse(Long totalCount, String cursorId, List<MeetupSummary> meetups) {
+		this.totalCount = totalCount;
+		this.cursorId = cursorId;
+		this.meetups = meetups;
+	}
+}

--- a/src/main/java/com/flab/mealmate/domain/meetup/dto/MeetupSummary.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/dto/MeetupSummary.java
@@ -1,0 +1,34 @@
+package com.flab.mealmate.domain.meetup.dto;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.flab.mealmate.domain.meetup.entity.ParticipationType;
+import com.flab.mealmate.domain.meetup.entity.RecruitmentStatus;
+
+import lombok.Getter;
+
+@Getter
+public class MeetupSummary {
+
+	private final String id;
+	private final String title;
+	private final String description;
+	@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+	private final LocalDateTime startDateTime;
+	private final ParticipationType participationType;
+	private final RecruitmentStatus recruitmentStatus;
+	private final long participants;
+
+	public MeetupSummary(Long id, String title, String description, LocalDateTime startDateTime,
+		ParticipationType participationType, RecruitmentStatus recruitmentStatus, long participants) {
+		this.id = String.valueOf(id);
+		this.title = title;
+		this.description = description;
+		this.startDateTime = startDateTime;
+		this.participationType = participationType;
+		this.recruitmentStatus = recruitmentStatus;
+		this.participants = participants;
+	}
+
+}

--- a/src/main/java/com/flab/mealmate/domain/meetup/mapper/MeetupSearchMapper.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/mapper/MeetupSearchMapper.java
@@ -1,0 +1,44 @@
+package com.flab.mealmate.domain.meetup.mapper;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import com.flab.mealmate.domain.meetup.dto.MeetupSearchCriteria;
+import com.flab.mealmate.domain.meetup.dto.MeetupSearchRequest;
+import com.flab.mealmate.domain.meetup.dto.MeetupSearchResponse;
+import com.flab.mealmate.domain.meetup.dto.MeetupSearchResult;
+import com.flab.mealmate.domain.meetup.dto.MeetupSummary;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MeetupSearchMapper {
+
+	public MeetupSearchCriteria toCriteria(MeetupSearchRequest request) {
+		return new MeetupSearchCriteria(PageRequest.ofSize(request.getSize()), request.getKeyword(), request.getCursorId());
+	}
+
+	public MeetupSearchResponse toResponse(Page<MeetupSearchResult> page) {
+		var meetups = page.getContent().stream()
+			.map(this::toSummary)
+			.toList();
+
+		var cursorId =  meetups.isEmpty() ? null : meetups.getLast().getId();
+
+		return new MeetupSearchResponse(page.getTotalElements(), cursorId, meetups);
+	}
+
+	private MeetupSummary toSummary(MeetupSearchResult row) {
+		return new MeetupSummary(
+			row.getId(),
+			row.getTitle(),
+			row.getDescription(),
+			row.getStartDateTime(),
+			row.getParticipationType(),
+			row.getRecruitmentStatus(),
+			row.getParticipants()
+		);
+	}
+}

--- a/src/test/java/com/flab/mealmate/domain/meetup/mapper/MeetupSearchMapperTest.java
+++ b/src/test/java/com/flab/mealmate/domain/meetup/mapper/MeetupSearchMapperTest.java
@@ -1,0 +1,89 @@
+package com.flab.mealmate.domain.meetup.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.support.PageableExecutionUtils;
+
+import com.flab.mealmate.domain.meetup.dto.MeetupSearchRequest;
+import com.flab.mealmate.domain.meetup.dto.MeetupSearchResult;
+import com.flab.mealmate.domain.meetup.entity.ParticipationType;
+import com.flab.mealmate.domain.meetup.entity.RecruitmentStatus;
+
+class MeetupSearchMapperTest {
+
+	private final MeetupSearchMapper mapper = new MeetupSearchMapper();
+
+	@Test
+	void toCriteriaMapsRequestToCriteriaSuccessfully() {
+		var request = new MeetupSearchRequest("신촌", 10, 100L);
+
+		var criteria = mapper.toCriteria(request);
+
+		assertEquals(request.getKeyword(), criteria.getKeyword());
+		assertEquals(request.getSize(), criteria.getPageable().getPageSize());
+		assertEquals(request.getCursorId(), criteria.getCursorId());
+	}
+
+	@Test
+	void toCriteriaMapsRequestWithNullCursorId() {
+		var request = new MeetupSearchRequest("신촌", 10, null);
+
+		var criteria = mapper.toCriteria(request);
+
+		assertNull(criteria.getCursorId());
+	}
+
+	@Test
+	void toResponseMapsEmptyPageWithNullCursorId() {
+		var expectedTotalCount = 0L;
+		var pageable = PageRequest.of(0, 10);
+
+		Page<MeetupSearchResult> emptyPage = PageableExecutionUtils.getPage(List.of(), pageable, () -> 0L);
+
+		var response = mapper.toResponse(emptyPage);
+
+		assertNotNull(response);
+		assertEquals(expectedTotalCount, response.getTotalCount());
+		assertNull(response.getCursorId());
+		assertTrue(response.getMeetups().isEmpty());
+	}
+
+	@Test
+	void toResponseMapsPageWithLastCursorId() {
+		var pageable = PageRequest.of(0, 10);
+		var result = new MeetupSearchResult(
+			123L,
+			"신촌에서 밥먹어요",
+			"샤브샤브 각",
+			LocalDateTime.of(2026, 1, 1, 12, 0),
+			ParticipationType.AUTO,
+			RecruitmentStatus.OPEN,
+			3
+		);
+
+
+		var page = PageableExecutionUtils.getPage(List.of(result), pageable, () -> 1L);
+
+		var expectedCursorId = "123";
+		var expectedTotalCount = 1L;
+
+		var response = mapper.toResponse(page);
+
+		assertNotNull(response);
+		assertEquals(expectedTotalCount, response.getTotalCount());
+		assertEquals(expectedCursorId, response.getCursorId());
+		assertEquals(1, response.getMeetups().size());
+		assertEquals(result.getTitle(), response.getMeetups().get(0).getTitle());
+	}
+}
+
+


### PR DESCRIPTION
## ✅ 개요  
`MeetupSearchMapper`를 구현하고, 관련 DTO와 단위 테스트를 통해 매핑 결과를 검증했습니다.

## ✅ 주요 변경 사항

- [x] `MeetupSearchMapper` 구현  
  - `toCriteria`: 검색 요청을 검색 조건 객체로 변환  
  - `toResponse`: 검색 결과 Page를 응답 DTO로 변환  
  - `toSummary`: 개별 검색 결과를 요약 DTO로 변환  

- [x] DTO 클래스 추가  
  -  검색용 전용 DTO 생성  
  - `MeetupSearchRequest`, `MeetupSearchCriteria`, `MeetupSearchResponse`, `MeetupSummary`   

- [x] 단위 테스트 추가  
  - `MeetupSearchMapper.toResponse()` 테스트  
    - 검색 결과가 비어 있는 경우: `cursorId`가 `null`  
    - 검색 결과가 존재하는 경우: 마지막 항목의 ID가 `cursorId`로 사용됨  
 - `MeetupSearchMapper.toCriteria()` 테스트  
    - 요청 객체의 필드를 기반으로 Criteria 객체 생성 여부 확인 

---

## 📎 관련 이슈 및 PR
- #7
- #12
