### PR TITLE
feat: add Meetup search API and service with tests

### DIFF
--- a/src/main/java/com/flab/mealmate/domain/meetup/api/MeetupApi.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/api/MeetupApi.java
@@ -1,14 +1,19 @@
 package com.flab.mealmate.domain.meetup.api;
 
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.flab.mealmate.domain.meetup.application.MeetupCreateService;
+import com.flab.mealmate.domain.meetup.application.MeetupSearchService;
 import com.flab.mealmate.domain.meetup.dto.MeetupCreateRequest;
 import com.flab.mealmate.domain.meetup.dto.MeetupCreateResponse;
+import com.flab.mealmate.domain.meetup.dto.MeetupSearchRequest;
+import com.flab.mealmate.domain.meetup.dto.MeetupSearchResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -18,10 +23,16 @@ import lombok.RequiredArgsConstructor;
 public class MeetupApi {
 
 	private final MeetupCreateService meetupCreateService;
+	private final MeetupSearchService meetupSearchService;
 
 	@PostMapping
 	public MeetupCreateResponse create(@RequestBody @Validated MeetupCreateRequest request) {
 		return meetupCreateService.create(request);
+	}
+
+	@GetMapping
+	public MeetupSearchResponse search(@ModelAttribute @Validated MeetupSearchRequest request) {
+		return meetupSearchService.search(request);
 	}
 
 }

--- a/src/main/java/com/flab/mealmate/domain/meetup/application/MeetupSearchService.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/application/MeetupSearchService.java
@@ -1,0 +1,9 @@
+package com.flab.mealmate.domain.meetup.application;
+
+import com.flab.mealmate.domain.meetup.dto.MeetupSearchRequest;
+import com.flab.mealmate.domain.meetup.dto.MeetupSearchResponse;
+
+public interface MeetupSearchService {
+
+	MeetupSearchResponse search(MeetupSearchRequest request);
+}

--- a/src/main/java/com/flab/mealmate/domain/meetup/application/MeetupSearchServiceV1.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/application/MeetupSearchServiceV1.java
@@ -1,0 +1,28 @@
+package com.flab.mealmate.domain.meetup.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.flab.mealmate.domain.meetup.dao.CustomMeetupRepository;
+import com.flab.mealmate.domain.meetup.dto.MeetupSearchRequest;
+import com.flab.mealmate.domain.meetup.dto.MeetupSearchResponse;
+import com.flab.mealmate.domain.meetup.mapper.MeetupSearchMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MeetupSearchServiceV1 implements MeetupSearchService {
+
+	private final MeetupSearchMapper searchMapper;
+	private final CustomMeetupRepository meetupRepository;
+
+	@Override
+	public MeetupSearchResponse search(MeetupSearchRequest request) {
+		var criteria = searchMapper.toCriteria(request);
+		var result = meetupRepository.page(criteria);
+
+		return searchMapper.toResponse(result);
+	}
+}

--- a/src/main/java/com/flab/mealmate/domain/meetup/dao/CustomMeetupRepository.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/dao/CustomMeetupRepository.java
@@ -1,0 +1,12 @@
+package com.flab.mealmate.domain.meetup.dao;
+
+import org.springframework.data.domain.Page;
+
+import com.flab.mealmate.domain.meetup.dto.MeetupSearchCriteria;
+import com.flab.mealmate.domain.meetup.dto.MeetupSearchResult;
+
+public interface CustomMeetupRepository {
+
+	Page<MeetupSearchResult> page(MeetupSearchCriteria criteria);
+
+}

--- a/src/main/java/com/flab/mealmate/domain/meetup/dao/MeetupQuerydslRepository.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/dao/MeetupQuerydslRepository.java
@@ -45,6 +45,7 @@ public class MeetupQuerydslRepository implements CustomMeetupRepository {
 				searchFullText(criteria.getKeyword())
 			)
 			.orderBy(meetup.id.desc())
+			.groupBy(meetup.id)
 			.limit(criteria.getPageSize())
 			.fetch();
 

--- a/src/main/java/com/flab/mealmate/domain/meetup/dao/MeetupQuerydslRepository.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/dao/MeetupQuerydslRepository.java
@@ -1,0 +1,75 @@
+package com.flab.mealmate.domain.meetup.dao;
+
+import static com.flab.mealmate.domain.meetup.entity.QMeetup.*;
+import static com.flab.mealmate.domain.meetup.entity.QMeetupParticipant.*;
+import static com.flab.mealmate.global.util.querydsl.BooleanExpressionUtils.*;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import com.flab.mealmate.domain.meetup.dto.MeetupSearchCriteria;
+import com.flab.mealmate.domain.meetup.dto.MeetupSearchResult;
+import com.flab.mealmate.domain.meetup.dto.QMeetupSearchResult;
+import com.flab.mealmate.domain.meetup.entity.ProgressStatus;
+import com.flab.mealmate.global.util.querydsl.FullTextSearchUtils;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class MeetupQuerydslRepository implements CustomMeetupRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public Page<MeetupSearchResult> page(MeetupSearchCriteria criteria) {
+		var content = queryFactory
+			.select(new QMeetupSearchResult(
+				meetup.id,
+				meetup.title,
+				meetup.content,
+				meetup.schedule.startDatetime,
+				meetup.participationType,
+				meetup.recruitmentStatus,
+				meetupParticipant.id.count()
+			))
+			.from(meetup)
+			.leftJoin(meetupParticipant)
+			.on(meetupParticipant.meetup.id.eq(meetup.id))
+			.where(
+				eqProgressStatus(criteria.getProgressStatus()),
+				ltId(criteria.getCursorId()),
+				searchFullText(criteria.getKeyword())
+			)
+			.orderBy(meetup.id.desc())
+			.limit(criteria.getPageSize())
+			.fetch();
+
+		var countQuery = queryFactory
+			.select(meetup.id.count())
+			.from(meetup)
+			.where(
+				eqProgressStatus(criteria.getProgressStatus()),
+				ltId(criteria.getCursorId()),
+				searchFullText(criteria.getKeyword())
+			);
+
+		return PageableExecutionUtils.getPage(content, criteria.getPageable(), countQuery::fetchOne);
+	}
+
+	private Predicate ltId(Long cursorId) {
+		return nullSafeBuilder(() -> meetup.id.lt(cursorId));
+	}
+
+	private Predicate searchFullText(String keyword) {
+		return FullTextSearchUtils.fullTextSearchBuilder(meetup.searchText, keyword);
+	}
+
+	private Predicate eqProgressStatus(ProgressStatus progressStatus) {
+		return nullSafeBuilder(() -> meetup.progressStatus.eq(progressStatus));
+	}
+
+}

--- a/src/main/java/com/flab/mealmate/domain/meetup/dto/MeetupSearchCriteria.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/dto/MeetupSearchCriteria.java
@@ -1,0 +1,28 @@
+package com.flab.mealmate.domain.meetup.dto;
+
+import static com.flab.mealmate.domain.meetup.entity.ProgressStatus.*;
+
+import org.springframework.data.domain.Pageable;
+
+import com.flab.mealmate.domain.meetup.entity.ProgressStatus;
+
+import lombok.Getter;
+
+@Getter
+public class MeetupSearchCriteria {
+
+	private final Pageable pageable;
+	private final String keyword;
+	private final Long cursorId;
+	private final ProgressStatus progressStatus = SCHEDULED;
+
+	public MeetupSearchCriteria(Pageable pageable, String keyword, Long cursorId) {
+		this.pageable = pageable;
+		this.keyword = keyword;
+		this.cursorId = cursorId;
+	}
+
+	public int getPageSize() {
+		return this.pageable.getPageSize();
+	}
+}

--- a/src/main/java/com/flab/mealmate/domain/meetup/dto/MeetupSearchRequest.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/dto/MeetupSearchRequest.java
@@ -1,0 +1,25 @@
+package com.flab.mealmate.domain.meetup.dto;
+
+import static com.flab.mealmate.domain.meetup.entity.ProgressStatus.SCHEDULED;
+
+import com.flab.mealmate.domain.meetup.entity.ProgressStatus;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class MeetupSearchRequest {
+
+	private final ProgressStatus progressStatus = SCHEDULED;
+	private final String keyword;
+	@NotNull @Max(value = 100)
+	private final int size;
+	private final Long cursorId;
+
+	public MeetupSearchRequest(String keyword, int size, Long cursorId) {
+		this.keyword = keyword;
+		this.size = size;
+		this.cursorId = cursorId;
+	}
+}

--- a/src/main/java/com/flab/mealmate/domain/meetup/dto/MeetupSearchResponse.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/dto/MeetupSearchResponse.java
@@ -1,0 +1,18 @@
+package com.flab.mealmate.domain.meetup.dto;
+
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class MeetupSearchResponse {
+	private final Long totalCount;
+	private final String  cursorId;
+	private final List<MeetupSummary> meetups;
+
+	public MeetupSearchResponse(Long totalCount, String cursorId, List<MeetupSummary> meetups) {
+		this.totalCount = totalCount;
+		this.cursorId = cursorId;
+		this.meetups = meetups;
+	}
+}

--- a/src/main/java/com/flab/mealmate/domain/meetup/dto/MeetupSearchResult.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/dto/MeetupSearchResult.java
@@ -1,0 +1,33 @@
+package com.flab.mealmate.domain.meetup.dto;
+
+import java.time.LocalDateTime;
+
+import com.flab.mealmate.domain.meetup.entity.ParticipationType;
+import com.flab.mealmate.domain.meetup.entity.RecruitmentStatus;
+import com.querydsl.core.annotations.QueryProjection;
+
+import lombok.Getter;
+
+@Getter
+public class MeetupSearchResult {
+
+	private final Long id;
+	private final String title;
+	private final String description;
+	private final LocalDateTime startDateTime;
+	private final ParticipationType participationType;
+	private final RecruitmentStatus recruitmentStatus;
+	private final long participants;
+
+	@QueryProjection
+	public MeetupSearchResult(Long id, String title, String description, LocalDateTime startDateTime,
+		ParticipationType participationType, RecruitmentStatus recruitmentStatus, long participants) {
+		this.id = id;
+		this.title = title;
+		this.description = description;
+		this.startDateTime = startDateTime;
+		this.participationType = participationType;
+		this.recruitmentStatus = recruitmentStatus;
+		this.participants = participants;
+	}
+}

--- a/src/main/java/com/flab/mealmate/domain/meetup/dto/MeetupSummary.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/dto/MeetupSummary.java
@@ -1,0 +1,34 @@
+package com.flab.mealmate.domain.meetup.dto;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.flab.mealmate.domain.meetup.entity.ParticipationType;
+import com.flab.mealmate.domain.meetup.entity.RecruitmentStatus;
+
+import lombok.Getter;
+
+@Getter
+public class MeetupSummary {
+
+	private final String id;
+	private final String title;
+	private final String description;
+	@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+	private final LocalDateTime startDateTime;
+	private final ParticipationType participationType;
+	private final RecruitmentStatus recruitmentStatus;
+	private final long participants;
+
+	public MeetupSummary(Long id, String title, String description, LocalDateTime startDateTime,
+		ParticipationType participationType, RecruitmentStatus recruitmentStatus, long participants) {
+		this.id = String.valueOf(id);
+		this.title = title;
+		this.description = description;
+		this.startDateTime = startDateTime;
+		this.participationType = participationType;
+		this.recruitmentStatus = recruitmentStatus;
+		this.participants = participants;
+	}
+
+}

--- a/src/main/java/com/flab/mealmate/domain/meetup/mapper/MeetupSearchMapper.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/mapper/MeetupSearchMapper.java
@@ -1,0 +1,44 @@
+package com.flab.mealmate.domain.meetup.mapper;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import com.flab.mealmate.domain.meetup.dto.MeetupSearchCriteria;
+import com.flab.mealmate.domain.meetup.dto.MeetupSearchRequest;
+import com.flab.mealmate.domain.meetup.dto.MeetupSearchResponse;
+import com.flab.mealmate.domain.meetup.dto.MeetupSearchResult;
+import com.flab.mealmate.domain.meetup.dto.MeetupSummary;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MeetupSearchMapper {
+
+	public MeetupSearchCriteria toCriteria(MeetupSearchRequest request) {
+		return new MeetupSearchCriteria(PageRequest.ofSize(request.getSize()), request.getKeyword(), request.getCursorId());
+	}
+
+	public MeetupSearchResponse toResponse(Page<MeetupSearchResult> page) {
+		var meetups = page.getContent().stream()
+			.map(this::toSummary)
+			.toList();
+
+		var cursorId =  meetups.isEmpty() ? null : meetups.getLast().getId();
+
+		return new MeetupSearchResponse(page.getTotalElements(), cursorId, meetups);
+	}
+
+	private MeetupSummary toSummary(MeetupSearchResult row) {
+		return new MeetupSummary(
+			row.getId(),
+			row.getTitle(),
+			row.getDescription(),
+			row.getStartDateTime(),
+			row.getParticipationType(),
+			row.getRecruitmentStatus(),
+			row.getParticipants()
+		);
+	}
+}

--- a/src/main/java/com/flab/mealmate/global/util/querydsl/BooleanExpressionUtils.java
+++ b/src/main/java/com/flab/mealmate/global/util/querydsl/BooleanExpressionUtils.java
@@ -1,0 +1,17 @@
+package com.flab.mealmate.global.util.querydsl;
+
+import java.util.function.Supplier;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+
+public class BooleanExpressionUtils {
+
+	public static BooleanBuilder nullSafeBuilder(Supplier<BooleanExpression> f) {
+		try {
+			return new BooleanBuilder(f.get());
+		} catch (IllegalArgumentException | NullPointerException e) {
+			return new BooleanBuilder();
+		}
+	}
+}

--- a/src/main/java/com/flab/mealmate/global/util/querydsl/FullTextSearchUtils.java
+++ b/src/main/java/com/flab/mealmate/global/util/querydsl/FullTextSearchUtils.java
@@ -1,0 +1,29 @@
+package com.flab.mealmate.global.util.querydsl;
+
+import org.springframework.util.StringUtils;
+
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberTemplate;
+import com.querydsl.core.types.dsl.StringPath;
+
+public class FullTextSearchUtils {
+
+	private static final String MATCH_QUERY_TEMPLATE = "match({0}) against ({1} in boolean mode)";
+	private static final double MINIMUM_MATCH_SCORE = 0.0;
+
+	public static Predicate fullTextSearchBuilder(StringPath fullTextColumn, String keyword) {
+		if (!StringUtils.hasText(keyword)) {
+			return null; // 키워드가 없으면 null 반환
+		}
+
+		NumberTemplate<Double> score = Expressions.numberTemplate(
+			Double.class,
+			MATCH_QUERY_TEMPLATE,
+			fullTextColumn,
+			Expressions.constant(keyword)
+		);
+
+		return score.gt(MINIMUM_MATCH_SCORE);
+	}
+}

--- a/src/test/java/com/flab/mealmate/domain/meetup/api/MeetupApiTest.java
+++ b/src/test/java/com/flab/mealmate/domain/meetup/api/MeetupApiTest.java
@@ -1,15 +1,20 @@
 package com.flab.mealmate.domain.meetup.api;
 
-import static com.flab.mealmate.global.ApiDocumentation.*;
-import static com.flab.mealmate.global.util.JsonUtils.*;
-import static org.mockito.BDDMockito.*;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
-import static org.springframework.restdocs.payload.JsonFieldType.*;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static com.flab.mealmate.global.ApiDocumentation.field;
+import static com.flab.mealmate.global.ApiDocumentation.parameter;
+import static com.flab.mealmate.global.util.JsonUtils.objectMapper;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,10 +27,16 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
+import com.epages.restdocs.apispec.SimpleType;
 import com.flab.mealmate.domain.meetup.application.MeetupCreateService;
+import com.flab.mealmate.domain.meetup.application.MeetupSearchService;
 import com.flab.mealmate.domain.meetup.dto.MeetupCreateRequest;
 import com.flab.mealmate.domain.meetup.dto.MeetupCreateResponse;
+import com.flab.mealmate.domain.meetup.dto.MeetupSearchRequest;
+import com.flab.mealmate.domain.meetup.dto.MeetupSearchResponse;
+import com.flab.mealmate.domain.meetup.dto.MeetupSummary;
 import com.flab.mealmate.domain.meetup.entity.ParticipationType;
+import com.flab.mealmate.domain.meetup.entity.RecruitmentStatus;
 import com.flab.mealmate.global.ApiDocumentation;
 
 
@@ -39,6 +50,9 @@ class MeetupApiTest {
 
 	@MockitoBean
 	private MeetupCreateService meetupCreateService;
+
+	@MockitoBean
+	private MeetupSearchService meetupSearchService;
 
 	private final String TAG = "meetup";
 
@@ -84,4 +98,46 @@ class MeetupApiTest {
 			.andDo(print());
 	}
 
+	@Test
+	@DisplayName("모임 검색 API")
+	void search() throws Exception {
+		var meetupSummary = new MeetupSummary(1L, "신촌에서 밥먹어요", "샤브샤브 각", LocalDateTime.of(2026, 1, 1, 12, 0, 0),
+			ParticipationType.AUTO, RecruitmentStatus.OPEN, 3L);
+		var response = new MeetupSearchResponse(1L, "1", List.of(meetupSummary));
+
+		given(meetupSearchService.search(any(MeetupSearchRequest.class)))
+			.willReturn(response);
+
+		ResultActions actions = mockMvc.perform(get("/meetups")
+				.param("keyword", "신촌")
+				.param("size", "10")
+				.param("cursorId", "100")
+				.with(csrf().asHeader())
+				.accept(MediaType.APPLICATION_JSON)
+			)
+			.andExpect(status().isOk());
+
+		actions.andDo(ApiDocumentation.builder()
+				.tag(TAG)
+				.description("모임 검색 API")
+				.requestParameters(
+					parameter("keyword", SimpleType.STRING, "검색 키워드").optional(),
+					parameter("size", SimpleType.NUMBER, "페이지 크기 (최대 100)"),
+					parameter("cursorId", SimpleType.NUMBER, "커서 ID (마지막 항목 기준)").optional()
+				)
+				.responseFields(
+					field("totalCount", NUMBER, "전체 모임 개수"),
+					field("cursorId", STRING, "마지막 항목의 ID"),
+					field("meetups[].id", STRING, "모임 ID"),
+					field("meetups[].title", STRING, "모임 제목"),
+					field("meetups[].description", STRING, "모임 설명"),
+					field("meetups[].startDateTime", STRING, "모임 시작 시간"),
+					field("meetups[].participationType", STRING, "참여 방식"),
+					field("meetups[].recruitmentStatus", STRING, "모집 상태"),
+					field("meetups[].participants", NUMBER, "참여 인원 수")
+				)
+				.build()
+			)
+			.andDo(print());
+	}
 }

--- a/src/test/java/com/flab/mealmate/domain/meetup/application/MeetupSearchServiceV1Test.java
+++ b/src/test/java/com/flab/mealmate/domain/meetup/application/MeetupSearchServiceV1Test.java
@@ -1,0 +1,64 @@
+package com.flab.mealmate.domain.meetup.application;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.support.PageableExecutionUtils;
+
+import com.flab.mealmate.domain.meetup.dao.CustomMeetupRepository;
+import com.flab.mealmate.domain.meetup.dto.MeetupSearchCriteria;
+import com.flab.mealmate.domain.meetup.dto.MeetupSearchRequest;
+import com.flab.mealmate.domain.meetup.dto.MeetupSearchResponse;
+import com.flab.mealmate.domain.meetup.dto.MeetupSearchResult;
+import com.flab.mealmate.domain.meetup.dto.MeetupSummary;
+import com.flab.mealmate.domain.meetup.entity.ParticipationType;
+import com.flab.mealmate.domain.meetup.entity.RecruitmentStatus;
+import com.flab.mealmate.domain.meetup.mapper.MeetupSearchMapper;
+
+@ExtendWith(MockitoExtension.class)
+class MeetupSearchServiceV1Test {
+
+	@Mock
+	private CustomMeetupRepository meetupRepository;
+
+	@Mock
+	private MeetupSearchMapper meetupSearchMapper;
+
+	@InjectMocks
+	private MeetupSearchServiceV1 meetupSearchService;
+
+	@Test
+	void search() {
+		var request = new MeetupSearchRequest("신촌", 100, null);
+		var criteria = new MeetupSearchCriteria(PageRequest.of(0, request.getSize()), request.getKeyword(), request.getCursorId());
+
+		var result = new MeetupSearchResult(1L, "신촌에서 밥먹을사람", "파스타 먹고싶어요", LocalDateTime.of(2026,1,1,12,0),
+			ParticipationType.APPROVAL, RecruitmentStatus.OPEN, 1);
+		var page = PageableExecutionUtils.getPage(List.of(result), criteria.getPageable(), () -> 1L);
+
+		var summary = new MeetupSummary(result.getId(), result.getTitle(), result.getDescription(), result.getStartDateTime(),
+			result.getParticipationType(), result.getRecruitmentStatus(), result.getParticipants());
+		var response = new MeetupSearchResponse(1L, "1", List.of(summary));
+
+		given(meetupSearchMapper.toCriteria(request)).willReturn(criteria);
+		given(meetupRepository.page(criteria)).willReturn(page);
+		given(meetupSearchMapper.toResponse(page)).willReturn(response);
+
+		meetupSearchService.search(request);
+
+		verify(meetupSearchMapper).toCriteria(request);
+		verify(meetupRepository).page(criteria);
+		verify(meetupSearchMapper).toResponse(page);
+
+	}
+
+}

--- a/src/test/java/com/flab/mealmate/domain/meetup/mapper/MeetupSearchMapperTest.java
+++ b/src/test/java/com/flab/mealmate/domain/meetup/mapper/MeetupSearchMapperTest.java
@@ -1,0 +1,89 @@
+package com.flab.mealmate.domain.meetup.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.support.PageableExecutionUtils;
+
+import com.flab.mealmate.domain.meetup.dto.MeetupSearchRequest;
+import com.flab.mealmate.domain.meetup.dto.MeetupSearchResult;
+import com.flab.mealmate.domain.meetup.entity.ParticipationType;
+import com.flab.mealmate.domain.meetup.entity.RecruitmentStatus;
+
+class MeetupSearchMapperTest {
+
+	private final MeetupSearchMapper mapper = new MeetupSearchMapper();
+
+	@Test
+	void toCriteriaMapsRequestToCriteriaSuccessfully() {
+		var request = new MeetupSearchRequest("신촌", 10, 100L);
+
+		var criteria = mapper.toCriteria(request);
+
+		assertEquals(request.getKeyword(), criteria.getKeyword());
+		assertEquals(request.getSize(), criteria.getPageable().getPageSize());
+		assertEquals(request.getCursorId(), criteria.getCursorId());
+	}
+
+	@Test
+	void toCriteriaMapsRequestWithNullCursorId() {
+		var request = new MeetupSearchRequest("신촌", 10, null);
+
+		var criteria = mapper.toCriteria(request);
+
+		assertNull(criteria.getCursorId());
+	}
+
+	@Test
+	void toResponseMapsEmptyPageWithNullCursorId() {
+		var expectedTotalCount = 0L;
+		var pageable = PageRequest.of(0, 10);
+
+		Page<MeetupSearchResult> emptyPage = PageableExecutionUtils.getPage(List.of(), pageable, () -> 0L);
+
+		var response = mapper.toResponse(emptyPage);
+
+		assertNotNull(response);
+		assertEquals(expectedTotalCount, response.getTotalCount());
+		assertNull(response.getCursorId());
+		assertTrue(response.getMeetups().isEmpty());
+	}
+
+	@Test
+	void toResponseMapsPageWithLastCursorId() {
+		var pageable = PageRequest.of(0, 10);
+		var result = new MeetupSearchResult(
+			123L,
+			"신촌에서 밥먹어요",
+			"샤브샤브 각",
+			LocalDateTime.of(2026, 1, 1, 12, 0),
+			ParticipationType.AUTO,
+			RecruitmentStatus.OPEN,
+			3
+		);
+
+
+		var page = PageableExecutionUtils.getPage(List.of(result), pageable, () -> 1L);
+
+		var expectedCursorId = "123";
+		var expectedTotalCount = 1L;
+
+		var response = mapper.toResponse(page);
+
+		assertNotNull(response);
+		assertEquals(expectedTotalCount, response.getTotalCount());
+		assertEquals(expectedCursorId, response.getCursorId());
+		assertEquals(1, response.getMeetups().size());
+		assertEquals(result.getTitle(), response.getMeetups().get(0).getTitle());
+	}
+}
+
+


### PR DESCRIPTION
## ✅ 개요  
`Meetup` 검색 기능의 API와 Service 레이어를 추가했습니다.  
사용자는 키워드 기반으로 진행 중인 모임을 검색할 수 있고 커서 기반 페이징 방식과 함께 검색 조건을 처리합니다.

## ✅ 주요 변경 사항

- [x] Meetup 검색 API 추가 (`GET /meetups`)
  - `MeetupSearchRequest`를 통해 검색 조건을 수신
  - 검색 결과는 `MeetupSearchResponse` 형태로 응답
  - 커서 기반 페이지네이션 방식 지원
  - 최신순으로 노출
  
- [x] MeetupSearchServiceV1 구현  
  - 검색 요청을 매퍼로 변환 → DB 조회 → 응답 매핑
  - 비즈니스 로직은 Mapper 클래스와 Repository 클래스에 위임

- [x] 테스트 추가  
  - `MeetupApiTest`: API 동작 및 문서화 테스트
  - `MeetupSearchServiceV1Test`: Repository/Mapper 상호작용 검증

---

## 📎 관련 이슈  
- #7
- #13 
