### PR TITLE
feat: Add Docker Compose setup for nGrinder Controller and Agent

### DIFF
--- a/docker/docker-compose.ngrinder.yml
+++ b/docker/docker-compose.ngrinder.yml
@@ -1,0 +1,22 @@
+services:
+  controller:
+    image: ngrinder/controller
+    container_name: controller
+    restart: always
+    ports:
+      - "9000:80"  # 브라우저에서 http://localhost:9000/login
+    volumes:
+      - ./ngrinder-controller:/opt/ngrinder-controller
+    networks:
+      - backend
+
+  agent:
+    image: ngrinder/agent
+    container_name: agent
+    restart: always
+    networks:
+      - backend
+
+networks:
+  backend:
+    driver: bridge


### PR DESCRIPTION
## ✅ 개요  
nGrinder 기반의 성능 테스트 환경을 로컬에서 구성할 수 있도록 `docker-compose.ngrinder.yml` 추가했습니다.  
Controller와 Agent를 같은 네트워크에서 자동 인식하도록 설정했습니다.

## ✅ 주요 변경 사항
- [x] `docker-compose.loadtest.yml` 파일 생성
  - nGrinder Controller, Agent 서비스 정의
  - `backend` 네트워크를 공유하여 자동 연결되도록 설정
  - Controller 포트는 `localhost:9000`으로 외부 노출
  - 설정/스크립트 보관용 볼륨(`./ngrinder-controller`) 추가

## ✅ 참고 사항
- 컨트롤러 접속 URL: `http://localhost:9000/login`
- Agent는 Controller 컨테이너와 동일한 네트워크(`backend`)에서 자동 인식
- nGrinder 관련 설정은 `/opt/ngrinder-controller`에 저장됨 (볼륨 사용)
- 추후 실제 대상 서비스 주소는 Web UI 또는 테스트 스크립트에서 지정 필요


