### PR TITLE
refactor: automatically add host as participant during Meetup creation

### DIFF
--- a/src/main/java/com/flab/mealmate/domain/meetup/application/MeetupCreateServiceV1.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/application/MeetupCreateServiceV1.java
@@ -3,12 +3,9 @@ package com.flab.mealmate.domain.meetup.application;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.flab.mealmate.domain.meetup.dao.MeetupParticipantRepository;
 import com.flab.mealmate.domain.meetup.dao.MeetupRepository;
 import com.flab.mealmate.domain.meetup.dto.MeetupCreateRequest;
 import com.flab.mealmate.domain.meetup.dto.MeetupCreateResponse;
-import com.flab.mealmate.domain.meetup.entity.Meetup;
-import com.flab.mealmate.domain.meetup.entity.MeetupParticipant;
 import com.flab.mealmate.domain.meetup.mapper.MeetupCreateMapper;
 import com.flab.mealmate.domain.meetup.policy.MeetupTimePolicy;
 import com.flab.mealmate.global.common.TimeProvider;
@@ -28,21 +25,13 @@ public class MeetupCreateServiceV1 implements MeetupCreateService {
 
 	private final TimeProvider timeProvider;
 
-	private final MeetupParticipantRepository meetupParticipantRepository;
-
 	@Override
 	public MeetupCreateResponse create(MeetupCreateRequest request) {
 		var meetUp = meetupCreateMapper.toEntity(request, timeProvider.now(), meetupTimePolicy);
-
 		meetupRepository.save(meetUp);
-		addHostAsParticipant(meetUp);
 
 		return meetupCreateMapper.toResponse(meetUp);
 	}
 
-	// 호스트 자동 추가 메서드
-	private void addHostAsParticipant(Meetup meetup) {
-		meetupParticipantRepository.save(MeetupParticipant.createHostParticipant(meetup));
-	}
 
 }

--- a/src/main/java/com/flab/mealmate/domain/meetup/dao/MeetupParticipantRepository.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/dao/MeetupParticipantRepository.java
@@ -1,8 +1,0 @@
-package com.flab.mealmate.domain.meetup.dao;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import com.flab.mealmate.domain.meetup.entity.MeetupParticipant;
-
-public interface MeetupParticipantRepository extends JpaRepository<MeetupParticipant, Long> {
-}

--- a/src/main/java/com/flab/mealmate/domain/meetup/entity/MeetupParticipant.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/entity/MeetupParticipant.java
@@ -38,21 +38,25 @@ public class MeetupParticipant extends BaseEntity {
 	@Comment("참여 신청 시 작성하는 내용")
 	private String applicationMessage;
 
-	private MeetupParticipant(Meetup meetup, ParticipationStatus participationStatus, String applicationMessage) {
+	private MeetupParticipant(Meetup meetup, ParticipationStatus participationStatus) {
 		this.meetup = meetup;
 		this.participationStatus = participationStatus;
+	}
+
+	private void setApplicationMessage(String applicationMessage) {
 		this.applicationMessage = applicationMessage;
 	}
 
-	public static MeetupParticipant createHostParticipant(Meetup meetup) {
-		return new MeetupParticipant(meetup, ParticipationStatus.APPROVED, null);
+	public static MeetupParticipant createParticipant(Meetup meetup, ParticipationStatus status) {
+		return new MeetupParticipant(meetup, status);
 	}
 
-	public static MeetupParticipant createPendingParticipant(Meetup meetup, String applicationMessage) {
-		return new MeetupParticipant(meetup, ParticipationStatus.PENDING, applicationMessage);
+	public static MeetupParticipant createParticipant(Meetup meetup, ParticipationStatus status, String applicationMessage) {
+		var participant = new MeetupParticipant(meetup, status);
+		participant.setApplicationMessage(applicationMessage);
+
+		return participant;
 	}
 
-	public static MeetupParticipant createApprovedParticipant(Meetup meetup) {
-		return new MeetupParticipant(meetup, ParticipationStatus.APPROVED, null);
-	}
+
 }

--- a/src/main/java/com/flab/mealmate/domain/meetup/mapper/MeetupCreateMapper.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/mapper/MeetupCreateMapper.java
@@ -18,7 +18,7 @@ public class MeetupCreateMapper {
 
 	public Meetup toEntity(MeetupCreateRequest request, LocalDateTime now, MeetupTimePolicy policy) {
 		var schedule = MeetupSchedule.create(request.getStartDateTime(), now, policy);
-		return new Meetup(
+		return Meetup.create(
 			request.getTitle(),
 			request.getContent(),
 			schedule,

--- a/src/test/java/com/flab/mealmate/domain/meetup/application/MeetupCreateServiceV1Test.java
+++ b/src/test/java/com/flab/mealmate/domain/meetup/application/MeetupCreateServiceV1Test.java
@@ -1,6 +1,5 @@
 package com.flab.mealmate.domain.meetup.application;
 
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -17,12 +16,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.flab.mealmate.domain.meetup.dao.MeetupParticipantRepository;
 import com.flab.mealmate.domain.meetup.dao.MeetupRepository;
 import com.flab.mealmate.domain.meetup.dto.MeetupCreateRequest;
 import com.flab.mealmate.domain.meetup.dto.MeetupCreateResponse;
 import com.flab.mealmate.domain.meetup.entity.Meetup;
-import com.flab.mealmate.domain.meetup.entity.MeetupParticipant;
 import com.flab.mealmate.domain.meetup.entity.MeetupSchedule;
 import com.flab.mealmate.domain.meetup.entity.ParticipationType;
 import com.flab.mealmate.domain.meetup.mapper.MeetupCreateMapper;
@@ -43,9 +40,6 @@ class MeetupCreateServiceV1Test {
 
 	@Mock
 	private TimeProvider timeProvider;
-
-	@Mock
-	private MeetupParticipantRepository meetupParticipantRepository;
 
 	@InjectMocks
 	private MeetupCreateServiceV1 meetupCreateService;
@@ -70,7 +64,7 @@ class MeetupCreateServiceV1Test {
 	@Test
 	void create() {
 		var schedule = MeetupSchedule.create(request.getStartDateTime(),request.getStartDateTime(), meetupTimePolicy);
-		var meetup = new Meetup("신촌에서 같이 밥먹을 사람", "샤브샤브 먹고싶어요.", schedule, ParticipationType.AUTO, 3, 5);
+		var meetup = Meetup.create("신촌에서 같이 밥먹을 사람", "샤브샤브 먹고싶어요.", schedule, ParticipationType.AUTO, 3, 5);
 		var response = new MeetupCreateResponse("1");
 
 		given(meetupCreateMapper.toEntity(
@@ -88,7 +82,6 @@ class MeetupCreateServiceV1Test {
 
 		verify(meetupCreateMapper, times(1)).toEntity(request, timeProvider.now(), meetupTimePolicy);
 		verify(meetupRepository, times(1)).save(meetup);
-		verify(meetupParticipantRepository, times(1)).save(any(MeetupParticipant.class));
 		verify(meetupCreateMapper, times(1)).toResponse(meetup);
 	}
 

--- a/src/test/java/com/flab/mealmate/domain/meetup/entity/MeetupTest.java
+++ b/src/test/java/com/flab/mealmate/domain/meetup/entity/MeetupTest.java
@@ -17,11 +17,14 @@ class MeetupTest {
 		var expectedProgressStatus = ProgressStatus.SCHEDULED;
 
 		var schedule = new MeetupSchedule();
-		var meetup = new Meetup("신촌에서 같이 밥먹을 사람",  "샤브샤브 먹고싶어요.", schedule, ParticipationType.AUTO, 3,5);
+		var meetup = Meetup.create("신촌에서 같이 밥먹을 사람",  "샤브샤브 먹고싶어요.", schedule, ParticipationType.AUTO, 3,5);
 
 		assertNotNull(meetup);
 		assertEquals(expectedRecruitmentStatus, meetup.getRecruitmentStatus());
 		assertEquals(expectedProgressStatus, meetup.getProgressStatus());
+
+		assertEquals(1, meetup.getParticipants().size());
+		assertEquals(ParticipationStatus.APPROVED, meetup.getParticipants().get(0).getParticipationStatus());
 	}
 
 	@Test
@@ -29,7 +32,7 @@ class MeetupTest {
 		var schedule = new MeetupSchedule();
 		var expected = ErrorCode.ERR_MEETUP_002;
 		BusinessException e = assertThrows(BusinessException.class, () -> {
-			new Meetup("신촌에서 같이 밥먹을 사람", "샤브샤브 먹고싶어요.", schedule, ParticipationType.AUTO, 5, 3);
+			Meetup.create("신촌에서 같이 밥먹을 사람", "샤브샤브 먹고싶어요.", schedule, ParticipationType.AUTO, 5, 3);
 		});
 
 		assertEquals(expected, e.getErrorCode());


### PR DESCRIPTION
## ✅ 개요  
Meetup 객체 생성 시 호스트 참가자를 자동으로 등록하도록 로직을 변경하였습니다.

## ✅ 주요 변경 사항
- [x] 기존에는 서비스 계층에서 명시적으로 `MeetupParticipant`를 추가했으나, `Meetup` 생성자 내부에서 자동 처리되도록 변경
- [x] 정적 팩토리 메서드 `create()` 추가 및 기존 생성자를 `private`으로 변경하여 객체 생성을 캡슐화
- [x] `MeetupParticipant`의 팩토리 메서드를 오버로딩하여,  
  신청 메시지가 필요한 경우와 그렇지 않은 경우를 구분
- [x] `MeetupParticipant` 생성자를 리팩토링하고, 필요한 경우를 위해 setter 메서드 추가

## ✅ 참고 사항
- Meetup 없이 MeetupParticipant는 생성될 수 없습니다.
- 도메인 관계상 항상 Meetup을 통해 생성되어야 합니다.


