### PR TITLE
feat(redis): add AOP-based distributed lock with Redisson

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,7 @@ dependencies {
 
     // DB
     runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.45.0'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/flab/mealmate/aop/AopForTransaction.java
+++ b/src/main/java/com/flab/mealmate/aop/AopForTransaction.java
@@ -1,0 +1,20 @@
+package com.flab.mealmate.aop;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * AOP에서 트랜잭션 분리를 위한 클래스
+ */
+
+@Component
+public class AopForTransaction {
+
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public Object proceed(final ProceedingJoinPoint joinPoint) throws Throwable {
+		return joinPoint.proceed();
+	}
+
+}

--- a/src/main/java/com/flab/mealmate/aop/DistributedLock.java
+++ b/src/main/java/com/flab/mealmate/aop/DistributedLock.java
@@ -1,0 +1,35 @@
+package com.flab.mealmate.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+
+	/**
+	 * 락 이름
+	 */
+	String key();
+
+	/**
+	 * 락 유효 시간 단위 : 초(sec)
+	 */
+	TimeUnit timeUnit() default TimeUnit.SECONDS;
+
+	/**
+	 * 락 획득을 위해 기다리는 시간
+	 * default : 5s
+	 */
+	long waitTime() default 5L;
+
+	/**
+	 * 락 획득 유지 시간
+	 * 락을 획득한 후 leaseTime이 끝나면 락 해제
+	 * waitTime보다 작은값
+	 * */
+	long leaseTime() default  3L;
+}

--- a/src/main/java/com/flab/mealmate/aop/DistributedLockAop.java
+++ b/src/main/java/com/flab/mealmate/aop/DistributedLockAop.java
@@ -1,0 +1,61 @@
+package com.flab.mealmate.aop;
+
+import java.lang.reflect.Method;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 특정 비즈니스 로직이나 도메인에 한정되지 않고, 범용적으로 사용할 수 있도록 AOP로 분리
+ */
+@Aspect
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DistributedLockAop {
+
+	private static final String REDISSON_LOCK_PREFIX = "LOCK:";
+	private final RedissonClient redissonClient;
+	private final AopForTransaction aopForTransaction;
+
+	@Around("@annotation(com.flab.mealmate.aop.DistributedLock)")
+	public Object lock(final ProceedingJoinPoint joinPoint) throws Throwable {
+		MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+		Method method = signature.getMethod();
+		DistributedLock distributedLock = method.getAnnotation(DistributedLock.class);
+
+		String key = REDISSON_LOCK_PREFIX + RedisKeyResolver.buildKey(signature.getParameterNames(), joinPoint.getArgs(), distributedLock.key());
+		// 락의 이름으로 RLock 인스턴스를 가져온다.
+		RLock rLock = redissonClient.getLock(key);
+
+		try {
+			// waitTime까지 Lock 획득을 시도한다.
+			boolean available = rLock.tryLock(distributedLock.waitTime(), distributedLock.leaseTime(), distributedLock.timeUnit());
+			if (!available) {
+				return false;
+			}
+			// DistributedLock 어노테이션이 선언된 메서드를 별도의 트랜잭션으로 실행한다.(aopForTransaction 정의)
+			return aopForTransaction.proceed(joinPoint);
+		} catch (InterruptedException e) {
+			throw new InterruptedException();
+		} finally {
+			try {
+				//종료시 무조건 락을 해제한다.
+				rLock.unlock();
+			} catch (IllegalMonitorStateException e) {
+				log.info("Redisson Lock Already UnLock {} {}",
+					method.getName(), key
+				);
+			}
+		}
+	}
+
+}

--- a/src/main/java/com/flab/mealmate/global/config/datasource/RedissonConfig.java
+++ b/src/main/java/com/flab/mealmate/global/config/datasource/RedissonConfig.java
@@ -1,0 +1,28 @@
+package com.flab.mealmate.global.config.datasource;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@Profile("!test")
+public class RedissonConfig {
+
+	@Value("${spring.data.redis.host}")
+	private String redisHost;
+
+	@Value("${spring.data.redis.port}")
+	private int redisPort;
+
+	@Bean
+	public RedissonClient redissonClient() {
+		Config config = new Config();
+		config.useSingleServer().setAddress(redisHost + ":" + redisPort);
+		RedissonClient redisson = Redisson.create(config);
+		return redisson;
+	}
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -15,6 +15,11 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
 
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+
   jackson:
     time-zone: Asia/Seoul
     jpa:

--- a/src/test/java/com/flab/mealmate/global/config/TestRedissonConfig.java
+++ b/src/test/java/com/flab/mealmate/global/config/TestRedissonConfig.java
@@ -1,0 +1,17 @@
+package com.flab.mealmate.global.config;
+
+import org.mockito.Mockito;
+import org.redisson.api.RedissonClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@Profile("test")
+public class TestRedissonConfig {
+
+	@Bean
+	public RedissonClient redissonClient() {
+		return Mockito.mock(RedissonClient.class);
+	}
+}


### PR DESCRIPTION
## ✅ 개요  
Redisson을 이용한 AOP 기반의 분산 락 기능을 구현했습니다.  

## ✅ 주요 변경 사항

- [X] `DistributedLockAop`
  - `@DistributedLock` 어노테이션 기반으로 메서드 진입 시 분산 락 획득
  - SpEL 키를 통해 락 키 생성 (RedisKeyResolver 사용)
  - 트랜잭션과 분리된 실행을 위해 `AopForTransaction` 분리 적용

- [X] `AopForTransaction`
  - `@Transactional(propagation = REQUIRES_NEW)` 설정으로 트랜잭션 재정의

- [X] `@DistributedLock` 어노테이션 추가
  - waitTime, leaseTime, key(SpEL) 속성 지원

## ✅ 참고 사항

- 락 키 형식은 PR #20  (`RedisKeyResolver`)에서 정의된 포맷을 사용합니다
- 테스트에서는 `@ActiveProfiles("test")`로 mock RedissonClient가 주입됩니다
- 향후 실제 Redis 띄워서 동작 테스트 시 Testcontainers 필요 
