### PR TITLE
feat : add MySqlLockExecutor, RedisLockExecutor and their test cases

### DIFF
--- a/src/main/java/com/flab/mealmate/aop/lock/LockExecutor.java
+++ b/src/main/java/com/flab/mealmate/aop/lock/LockExecutor.java
@@ -1,0 +1,9 @@
+package com.flab.mealmate.aop.lock;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+public interface LockExecutor {
+	<T> T execute(String key, int waitTime, int leaseTime, TimeUnit timeUnit, Supplier<T> action);
+
+}

--- a/src/main/java/com/flab/mealmate/aop/lock/MySqlLockExecutor.java
+++ b/src/main/java/com/flab/mealmate/aop/lock/MySqlLockExecutor.java
@@ -1,0 +1,77 @@
+package com.flab.mealmate.aop.lock;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import javax.sql.DataSource;
+
+import org.springframework.stereotype.Component;
+
+import com.flab.mealmate.global.error.exception.BusinessException;
+import com.flab.mealmate.global.error.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MySqlLockExecutor implements LockExecutor {
+
+	private final DataSource writeDataSource;
+	private final String MYSQL_LOCK_PREFIX = "LOCK:";
+
+	@Override
+	public <T> T execute(String key, int waitTime, int leaseTime, TimeUnit timeUnit, Supplier<T> action) {
+		String fullKey = MYSQL_LOCK_PREFIX + key;
+
+		try (Connection conn = writeDataSource.getConnection()) {
+
+			if (!acquireLock(conn, fullKey, waitTime)) {
+				log.warn("MySQL 락 획득 실패: {}", fullKey);
+				throw new BusinessException(ErrorCode.ERR_DB);
+			}
+
+			try {
+				return action.get();
+			} finally {
+				releaseLock(conn, fullKey);
+			}
+
+		} catch (SQLException e) {
+			log.error("MySQL 연결 실패: {}", e);
+			throw new BusinessException(ErrorCode.ERR_DB);
+		}
+	}
+
+
+	private boolean acquireLock(Connection conn, String fullKey, int timeoutSeconds) {
+		try (PreparedStatement stmt = conn.prepareStatement("SELECT GET_LOCK(?, ?)")) {
+			stmt.setString(1, fullKey);
+			stmt.setInt(2, timeoutSeconds);
+			try (ResultSet rs = stmt.executeQuery()) {
+				return rs.next() && rs.getInt(1) == 1;
+			}
+		} catch (SQLException e) {
+			log.error("MySQL 락 획득 중 SQLException 발생: {}", fullKey, e);
+			throw new BusinessException(ErrorCode.ERR_DB);
+		}
+	}
+
+	private void releaseLock(Connection conn, String fullKey) {
+		try (PreparedStatement stmt = conn.prepareStatement("SELECT RELEASE_LOCK(?)")) {
+			stmt.setString(1, fullKey);
+			stmt.execute();
+			log.debug("MySQL 락 해제 완료: {}", fullKey);
+		} catch (SQLException e) {
+			log.error("MySQL 락 해제 중 SQLException 발생: {}", fullKey, e);
+			throw new BusinessException(ErrorCode.ERR_DB);
+		}
+	}
+
+}
+

--- a/src/main/java/com/flab/mealmate/aop/lock/RedisLockExecutor.java
+++ b/src/main/java/com/flab/mealmate/aop/lock/RedisLockExecutor.java
@@ -1,0 +1,56 @@
+package com.flab.mealmate.aop.lock;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import com.flab.mealmate.global.error.exception.BusinessException;
+import com.flab.mealmate.global.error.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisLockExecutor implements LockExecutor {
+
+	private final RedissonClient redissonClient;
+
+	private final String REDIS_LOCK_PREFIX = "LOCK:";
+
+	@Override
+	public <T> T execute(String key, int waitTime, int leaseTime, TimeUnit timeUnit, Supplier<T> action) {
+		String fullKey = REDIS_LOCK_PREFIX + key;
+		RLock lock = redissonClient.getLock(fullKey);
+
+		boolean acquired = false;
+
+		try {
+			acquired = lock.tryLock(waitTime, leaseTime, timeUnit);
+			if (!acquired) {
+				log.warn("Redis 락 획득 실패: {}", fullKey);
+				throw new BusinessException(ErrorCode.ERR_DB, new String[]{fullKey});
+			}
+			// 락을 획득한 상태에서만 action 수행
+			return action.get();
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			log.error("Redis 락 대기 중 인터럽트 발생: {}", fullKey, e);
+			throw new BusinessException(ErrorCode.ERR_DB, new String[]{fullKey});
+		} finally {
+			if (acquired) { // 락을 획득한 경우에만 해제
+				try {
+					lock.unlock();
+				} catch (IllegalMonitorStateException e) {
+					log.error("Redis 락 해제 실패: {}", fullKey, e);
+					throw new BusinessException(ErrorCode.ERR_DB, new String[]{fullKey});
+				}
+			}
+		}
+	}
+}
+

--- a/src/test/java/com/flab/mealmate/aop/lock/MySqlLockExecutorTest.java
+++ b/src/test/java/com/flab/mealmate/aop/lock/MySqlLockExecutorTest.java
@@ -1,0 +1,65 @@
+package com.flab.mealmate.aop.lock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.flab.mealmate.global.config.AbstractMySqlTestContainer;
+import com.flab.mealmate.global.error.exception.BusinessException;
+import com.flab.mealmate.global.error.exception.ErrorCode;
+
+class MySqlLockExecutorTest extends AbstractMySqlTestContainer {
+
+	@Autowired
+	MySqlLockExecutor lockExecutor;
+
+	@Test
+	void lockSuccessfully(){
+		String result = lockExecutor.execute("LOCK:meetup-123", 5, 5, TimeUnit.SECONDS, () -> "락성공!");
+		assertThat(result).isEqualTo("락성공!");
+	}
+
+	@Test
+	void throwsExceptionWhenLockIsAlreadyHeld() throws InterruptedException {
+		String lockName = "LOCK:meetup-123";
+		CountDownLatch lockAcquired = new CountDownLatch(1); // thread1이 락을 획득했음을 알리는 신호
+		CountDownLatch releaseSignal = new CountDownLatch(1); // thread1이 락을 해제할 수 있게 해주는 신호
+
+		Thread thread1 = new Thread(() -> {
+			lockExecutor.execute(
+				lockName,
+				5,
+				5,
+				TimeUnit.SECONDS,
+				() -> {
+					lockAcquired.countDown(); // 락을 획득했음을 main thread에 알림
+					awaitQuietly(releaseSignal); // main thread가 해제 신호를 줄 때까지 대기 → 락 점유 유지
+					return null;
+				});
+		});
+		thread1.start(); // thread 1 시작 -> thread 1이 먼저 lock 점유
+		lockAcquired.await(); // thread1이 락을 잡을 때까지 main thread는 대기
+
+		// 이미 thread 1에서 lock을 점유했기 때문에 예외가 발생해야 함
+		assertThatThrownBy(() ->
+			lockExecutor.execute(lockName, 5, 5, TimeUnit.SECONDS, () -> "실패해야 함")
+		).isInstanceOf(BusinessException.class)
+			.hasMessageContaining(ErrorCode.ERR_DB.getValue());
+
+		releaseSignal.countDown(); // thread 1이 lock 반납하도록 신호
+		thread1.join(); // thread1 종료까지 대기
+	}
+
+	private void awaitQuietly(CountDownLatch latch) {
+		try {
+			latch.await();
+		} catch (InterruptedException ignored) {
+		}
+	}
+
+}

--- a/src/test/java/com/flab/mealmate/aop/lock/RedisLockExecutorTest.java
+++ b/src/test/java/com/flab/mealmate/aop/lock/RedisLockExecutorTest.java
@@ -1,0 +1,78 @@
+package com.flab.mealmate.aop.lock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.flab.mealmate.global.config.AbstractRedisTestContainer;
+import com.flab.mealmate.global.error.exception.BusinessException;
+import com.flab.mealmate.global.error.exception.ErrorCode;
+
+public class RedisLockExecutorTest extends AbstractRedisTestContainer {
+
+	@Autowired
+	private RedisLockExecutor lockExecutor;
+
+	@Test
+	void lockSuccessfully() {
+		String result = lockExecutor.execute(
+			"LOCK:meetup-123",
+			5,
+			5,
+			TimeUnit.SECONDS,
+			() -> "락성공!"
+		);
+		assertThat(result).isEqualTo("락성공!");
+	}
+
+	@Test
+	void throwsExceptionWhenLockIsAlreadyHeld() throws InterruptedException {
+		String lockName = "LOCK:meetup-123";
+		CountDownLatch lockAcquired   = new CountDownLatch(1);
+		CountDownLatch releaseSignal  = new CountDownLatch(1);
+
+		Thread thread1 = new Thread(() -> {
+			lockExecutor.execute(
+				lockName,
+				5,
+				5,
+				TimeUnit.SECONDS,
+				() -> {
+					lockAcquired.countDown();         // 락 획득 알림
+					awaitQuietly(releaseSignal);     // 해제 신호 전까지 대기
+					return null;
+				}
+			);
+		});
+		thread1.start();
+		lockAcquired.await(); // thread1이 락을 잡을 때까지 대기
+
+		// 이미 락이 점유되었으므로 예외 발생
+		assertThatThrownBy(() ->
+			lockExecutor.execute(
+				lockName,
+				5,
+				5,
+				TimeUnit.SECONDS,
+				() -> "실패해야 함"
+			)
+		)
+			.isInstanceOf(BusinessException.class)
+			.hasMessageContaining(ErrorCode.ERR_DB.getValue());
+
+		// 해제 신호 보내고 thread1 종료 대기
+		releaseSignal.countDown();
+		thread1.join();
+	}
+
+	private void awaitQuietly(CountDownLatch latch) {
+		try {
+			latch.await();
+		} catch (InterruptedException ignored) { }
+	}
+}

--- a/src/test/java/com/flab/mealmate/global/config/AbstractMySqlTestContainer.java
+++ b/src/test/java/com/flab/mealmate/global/config/AbstractMySqlTestContainer.java
@@ -3,15 +3,19 @@ package com.flab.mealmate.global.config;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 @SpringJUnitConfig
+@ContextConfiguration(classes = MySqlTestConfig.class)
 @ImportAutoConfiguration(DataSourceAutoConfiguration.class)
 @ActiveProfiles("container-test")
+@Testcontainers
 public abstract class AbstractMySqlTestContainer {
 
 	private static final String MYSQL_IMAGE = "mysql:8.2";

--- a/src/test/java/com/flab/mealmate/global/config/AbstractRedisTestContainer.java
+++ b/src/test/java/com/flab/mealmate/global/config/AbstractRedisTestContainer.java
@@ -1,6 +1,7 @@
 package com.flab.mealmate.global.config;
 
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
@@ -10,6 +11,7 @@ import org.testcontainers.utility.DockerImageName;
 
 @SpringJUnitConfig
 @ActiveProfiles("container-test")
+@ContextConfiguration(classes = RedisContainerTestConfig.class)
 @Testcontainers
 public abstract class AbstractRedisTestContainer {
 

--- a/src/test/java/com/flab/mealmate/global/config/MySqlTestConfig.java
+++ b/src/test/java/com/flab/mealmate/global/config/MySqlTestConfig.java
@@ -1,0 +1,20 @@
+package com.flab.mealmate.global.config;
+
+import javax.sql.DataSource;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import com.flab.mealmate.aop.lock.MySqlLockExecutor;
+
+@Configuration
+@Profile("container-test")
+public class MySqlTestConfig {
+
+	@Bean
+	public MySqlLockExecutor mySqlLockExecutor(DataSource dataSource) {
+		return new MySqlLockExecutor(dataSource);
+	}
+
+}

--- a/src/test/java/com/flab/mealmate/global/config/RedisContainerTestConfig.java
+++ b/src/test/java/com/flab/mealmate/global/config/RedisContainerTestConfig.java
@@ -1,0 +1,41 @@
+package com.flab.mealmate.global.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import com.flab.mealmate.aop.lock.RedisLockExecutor;
+
+@Configuration
+@Profile("container-test")
+public class RedisContainerTestConfig {
+
+	@Value("${spring.data.redis.host}")
+	private String redisHost;
+
+	@Value("${spring.data.redis.port}")
+	private Integer redisPort;
+
+	@Bean
+	public RedissonClient redissonClient() {
+		Config config = new Config();
+		String address = redisHost.startsWith("redis://")
+			? redisHost + ":" + redisPort
+			: "redis://" + redisHost + ":" + redisPort;
+
+		config.useSingleServer()
+			.setAddress(address);
+
+		return Redisson.create(config);
+	}
+
+	@Bean
+	public RedisLockExecutor redisLockExecutor(RedissonClient client) {
+		return new RedisLockExecutor(client);
+	}
+
+}

--- a/src/test/java/com/flab/mealmate/global/config/RedisMockConfig.java
+++ b/src/test/java/com/flab/mealmate/global/config/RedisMockConfig.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Profile;
 
 @Configuration
 @Profile("test")
-public class TestRedissonConfig {
+public class RedisMockConfig {
 
 	@Bean
 	public RedissonClient redissonClient() {


### PR DESCRIPTION
## ✅  개요
`RedisLockExecutor`와 `MySqlLockExecutor`를 추가하고, 이들을 검증하기 위한 테스트 코드 및 설정 클래스를 도입했습니다.
- **MySqlTestConfig**: MySQL Testcontainers 환경 설정  
- **RedisContainerTestConfig**: Redis Testcontainers 환경 설정  
- **RedisMockConfig**: Mockito 기반 mock `RedissonClient` 설정  


## ✅ 주요 변경사항
- [X] Executor 및 테스트 추가  
  - `MySqlLockExecutor` + `MySqlLockExecutorTest`  
  - `RedisLockExecutor` + `RedisLockExecutorTest`  
- [X] Redis config 분리  
  - Testcontainers 기반 통합 테스트(`container-test`)와 Mockito mock 테스트(`test`)를 프로파일로 분리  
  
## ✅ 질문
MySqlLockExecutor 및 RedisLockExecutor 구현체에서 DB/Redis 관련 예외를 BusinessException으로 일괄 변환하고, 구체적인 스택 트레이스 등은 로그에만 남기도록 처리했습니다. 이와 같은 예외 변환 및 로깅 전략이 모범 사례에 부합하는 설계인지 궁금합니다.
