### PR TITLE
refactor: apply LockExecutor to Meetup participation flow

### DIFF
--- a/src/main/java/com/flab/mealmate/domain/meetup/application/MeetupWithLockFactory.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/application/MeetupWithLockFactory.java
@@ -1,0 +1,22 @@
+package com.flab.mealmate.domain.meetup.application;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import com.flab.mealmate.domain.meetup.entity.Meetup;
+import com.flab.mealmate.domain.meetup.entity.MeetupWithLock;
+import com.flab.mealmate.infra.lock.LockExecutor;
+
+@Component
+public class MeetupWithLockFactory {
+
+	private final LockExecutor lockExecutor;
+
+	public MeetupWithLockFactory(@Qualifier("redisLockExecutor")LockExecutor lockExecutor) {
+		this.lockExecutor = lockExecutor;
+	}
+
+	public MeetupWithLock create(Meetup meetup) {
+		return new MeetupWithLock(meetup, lockExecutor);
+	}
+}

--- a/src/main/java/com/flab/mealmate/domain/meetup/application/participation/AutoParticipationStrategy.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/application/participation/AutoParticipationStrategy.java
@@ -4,7 +4,9 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 
+import com.flab.mealmate.domain.meetup.application.MeetupWithLockFactory;
 import com.flab.mealmate.domain.meetup.entity.Meetup;
+import com.flab.mealmate.domain.meetup.entity.MeetupWithLock;
 import com.flab.mealmate.domain.meetup.entity.ParticipationType;
 
 import lombok.RequiredArgsConstructor;
@@ -13,6 +15,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AutoParticipationStrategy implements ParticipationStrategy {
 
+	private final MeetupWithLockFactory meetupWithLockFactory;
+
 	@Override
 	public ParticipationType getType() {
 		return ParticipationType.AUTO;
@@ -20,8 +24,8 @@ public class AutoParticipationStrategy implements ParticipationStrategy {
 
 	@Override
 	public void participate(Meetup meetup, Optional<String> applicationMessage, Long userId) {
-		// AUTO 타입은 자동으로 신청되어 applicationMessage를 사용하지 않음
-		meetup.addAutoApprovedParticipant(userId);
+		MeetupWithLock meetupWithLock = meetupWithLockFactory.create(meetup);
+		meetupWithLock.addAutoApprovedParticipant(userId);
 	}
 
 }

--- a/src/main/java/com/flab/mealmate/domain/meetup/entity/Meetup.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/entity/Meetup.java
@@ -93,11 +93,12 @@ public class Meetup extends BaseEntity {
 		return new Meetup(title, content, meetupSchedule, participationType, minParticipants, maxParticipants);
 	}
 
-	public void addAutoApprovedParticipant(Long userId) {
+	void addAutoApprovedParticipant(Long userId) {
 		validateDuplicateParticipant(userId);
 		validateMaxParticipantsNotExceeded();
 		this.participants.add(MeetupParticipant.createParticipant(this, ParticipationStatus.APPROVED));
 	}
+
 	public void addPendingParticipant(String applicationMessage, Long userId) {
 		validateDuplicateParticipant(userId);
 		this.participants.add(MeetupParticipant.createParticipant(this, ParticipationStatus.PENDING, applicationMessage));

--- a/src/main/java/com/flab/mealmate/domain/meetup/entity/MeetupWithLock.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/entity/MeetupWithLock.java
@@ -1,0 +1,22 @@
+package com.flab.mealmate.domain.meetup.entity;
+
+import com.flab.mealmate.infra.lock.LockExecutionContext;
+import com.flab.mealmate.infra.lock.LockExecutor;
+
+public class MeetupWithLock {
+
+	private final Meetup meetup;
+	private final LockExecutor lockExecutor;
+
+	public MeetupWithLock(Meetup meetup, LockExecutor lockExecutor) {
+		this.meetup = meetup;
+		this.lockExecutor = lockExecutor;
+	}
+
+	public void addAutoApprovedParticipant(Long userId) {
+		LockExecutionContext.with(this.lockExecutor)
+			.buildKey(new String[] {"meetup"}, new Object[] {meetup.getId()})
+			.executeWithTask(() -> meetup.addAutoApprovedParticipant(userId));
+	}
+
+}

--- a/src/test/java/com/flab/mealmate/domain/meetup/entity/MeetupWithLockConcurrencyTest.java
+++ b/src/test/java/com/flab/mealmate/domain/meetup/entity/MeetupWithLockConcurrencyTest.java
@@ -30,7 +30,7 @@ public class MeetupWithLockConcurrencyTest extends AbstractRedisTestContainer {
 	}
 
 	@Test
-	void NotExceedsMaxParticipantsWithLocking() throws InterruptedException {
+	void notExceedsMaxParticipantsWithLocking() throws InterruptedException {
 		int threadCount = 10;
 		CountDownLatch startLatch = new CountDownLatch(1);
 		CountDownLatch doneLatch = new CountDownLatch(threadCount);

--- a/src/test/java/com/flab/mealmate/domain/meetup/entity/MeetupWithLockConcurrencyTest.java
+++ b/src/test/java/com/flab/mealmate/domain/meetup/entity/MeetupWithLockConcurrencyTest.java
@@ -1,0 +1,71 @@
+package com.flab.mealmate.domain.meetup.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.flab.mealmate.domain.model.User;
+import com.flab.mealmate.global.config.AbstractRedisTestContainer;
+import com.flab.mealmate.global.error.exception.BusinessException;
+import com.flab.mealmate.infra.lock.RedisLockExecutor;
+
+public class MeetupWithLockConcurrencyTest extends AbstractRedisTestContainer {
+
+	@Autowired
+	private RedisLockExecutor executor;
+
+	private Meetup meetup;
+
+	@BeforeEach
+	void setUp() {
+		meetup = MeetupMock.createAuto(1, 2); // 최대 2명
+		Long hostId = 1L;
+		ReflectionTestUtils.setField(meetup, "createdBy", new User(hostId, String.valueOf(hostId)));
+	}
+
+	@Test
+	void NotExceedsMaxParticipantsWithLocking() throws InterruptedException {
+		int threadCount = 10;
+		CountDownLatch startLatch = new CountDownLatch(1);
+		CountDownLatch doneLatch = new CountDownLatch(threadCount);
+		AtomicInteger exception = new AtomicInteger();
+
+		MeetupWithLock meetupWithLock = new MeetupWithLock(meetup, executor);
+
+		for (int i = 0; i < threadCount; i++) {
+			final long userId = 1000L + i;
+
+			new Thread(() -> {
+				awaitQuietly(startLatch);
+				try {
+					meetupWithLock.addAutoApprovedParticipant(userId);
+					var participant = meetup.getParticipants().get(meetup.getParticipants().size() - 1);
+					ReflectionTestUtils.setField(participant, "createdBy", new User(userId, String.valueOf(userId)));
+				} catch (BusinessException ignored) {
+					exception.getAndIncrement();
+				} finally {
+					doneLatch.countDown();
+				}
+			}).start();
+		}
+
+		startLatch.countDown(); // 모든 스레드 동시에 시작
+		doneLatch.await();      // 모두 완료될 때까지 대기
+
+		assertThat(meetup.getParticipants().size()).isLessThanOrEqualTo(2);
+		assertThat(exception.get()).isEqualTo(9);
+	}
+
+	private void awaitQuietly(CountDownLatch latch) {
+		try {
+			latch.await();
+		} catch (InterruptedException ignored) {
+		}
+	}
+}

--- a/src/test/java/com/flab/mealmate/domain/meetup/entity/MeetupWithLockTest.java
+++ b/src/test/java/com/flab/mealmate/domain/meetup/entity/MeetupWithLockTest.java
@@ -1,0 +1,54 @@
+package com.flab.mealmate.domain.meetup.entity;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.flab.mealmate.infra.lock.LockExecutor;
+
+@ExtendWith(MockitoExtension.class)
+class MeetupWithLockTest {
+
+	@Mock
+	private Meetup meetup;
+
+	@Mock
+	private LockExecutor lockExecutor;
+
+	@Test
+	void addAutoApprovedParticipantSuccessfully() {
+		// given
+		Long meetupId = 1L;
+		Long userId = 123L;
+		MeetupWithLock meetupWithLock = new MeetupWithLock(meetup, lockExecutor);
+
+		given(meetup.getId()).willReturn(meetupId);
+		given(lockExecutor.execute(anyString(), anyInt(), anyInt(), any(TimeUnit.class), any()))
+			.willAnswer(invocation -> {
+				Supplier supplier = invocation.getArgument(4);
+				return supplier.get();
+			});
+
+		// when
+		meetupWithLock.addAutoApprovedParticipant(userId);
+
+		// then
+		verify(lockExecutor, times(1))
+			.execute(anyString(), anyInt(), anyInt(), any(TimeUnit.class), any());
+		verify(meetup, times(1))
+			.addAutoApprovedParticipant(userId);
+
+	}
+
+}

--- a/src/test/java/com/flab/mealmate/domain/meetup/strategy/AutoParticipationStrategyTest.java
+++ b/src/test/java/com/flab/mealmate/domain/meetup/strategy/AutoParticipationStrategyTest.java
@@ -1,44 +1,68 @@
 package com.flab.mealmate.domain.meetup.strategy;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.flab.mealmate.domain.meetup.application.MeetupWithLockFactory;
 import com.flab.mealmate.domain.meetup.application.participation.AutoParticipationStrategy;
 import com.flab.mealmate.domain.meetup.entity.Meetup;
 import com.flab.mealmate.domain.meetup.entity.MeetupMock;
-import com.flab.mealmate.domain.meetup.entity.MeetupParticipant;
-import com.flab.mealmate.domain.meetup.entity.ParticipationStatus;
+import com.flab.mealmate.domain.meetup.entity.MeetupWithLock;
+import com.flab.mealmate.infra.lock.LockExecutor;
 
 @ExtendWith(MockitoExtension.class)
 class AutoParticipationStrategyTest {
 	private static final Long USER_ID = 123L;
 
-	private Meetup meetup;
+	@Mock
+	MeetupWithLockFactory meetupWithLockFactory;
+
+	@Mock
+	LockExecutor lockExecutor;
 
 	@InjectMocks
-	private AutoParticipationStrategy strategy;
+	AutoParticipationStrategy strategy;
+
+	Meetup meetup;
 
 	@BeforeEach
 	void setUp() {
 		meetup = MeetupMock.createAuto(1, 3);
 	}
+
 	@Test
 	void participateSuccessfully() {
+		// given
+		var meetupWithLock = new MeetupWithLock(meetup, lockExecutor);
+		when(meetupWithLockFactory.create(meetup)).thenReturn(meetupWithLock);
+		when(lockExecutor.execute(anyString(), anyInt(), anyInt(), any(TimeUnit.class), any()))
+			.thenAnswer(invocation -> {
+				Supplier action = invocation.getArgument(4);
+				return action.get();
+			});
+
 		// when
 		strategy.participate(meetup, Optional.empty(), USER_ID);
 
 		// then
+		verify(lockExecutor, times(1)).execute(anyString(), anyInt(), anyInt(), any(TimeUnit.class), any());
 		assertThat(meetup.getParticipants()).hasSize(2);
-		MeetupParticipant participant = meetup.getParticipants().get(1);
-
-		assertThat(participant.getParticipationStatus()).isEqualTo(ParticipationStatus.APPROVED);
 	}
 
 }


### PR DESCRIPTION
## ✅ 작업 개요
Meetup 동시에 여러 사용자가 참가 요청을 보낼 때 발생할 수 있는 동시성 문제를 해결합니다.  
Redis 기반의 분산 락을 활용해 `maxParticipants` 제한을 안정적으로 보장할 수 있도록 구조를 개선했습니다.

## ✅ 주요 변경사항

- [X] `MeetupWithLock' 클래스 추가  
  - `Meetup` 객체와 `LockExecutor`를 조합하여 락을 걸고 안전하게 참가 로직을 실행
- [X] `MeetupWithLockFactory` 추가  
  - `RedisLockExecutor`가 주입된 `MeetupWithLock`을 생성하는 책임 분리
- [X] `AutoParticipationStrategy` 내부 로직 변경  
  - 기존 `meetup.addAutoApprovedParticipant()` 직접 호출 대신 `MeetupWithLock`을 사용
- [X] 동시성 테스트 수정 및 추가
  - `MeetupTest` 클래스 `exceedsMaxParticipantsWithoutLocking()` 테스트 수정
  - `MeetupWithLockConcurrencyTest` 클래스 `notExceedsMaxParticipantsWithLocking()`
    - 테스트 컨테이너 기반의 Redis 사용 (`AbstractRedisTestContainer` 활용)
  
##  ✅ 계속 고민인 사항
- 동시성 제어를 위해 `MeetupWithLock` 객체를 도메인 패키지에 배치했지만, LockExecutor라는 인프라 의존성을 갖게 되어 계층 구조가 다소 애매하다고 느꼈습니다.
- 락이 필요한 메서드(`addAutoApprovedParticipant`)는 package-private으로 제한하여 외부(application layer)에서는 반드시 `MeetupWithLock`을 통해 호출하도록 강제했습니다.  
  다만, 실무에서는 package-private 접근 제어자를 명시적으로 사용하는 경우가 드물었기 때문에, 이 방식이 최선인지에 대한 고민입니다.
