### PR TITLE
feat: apply ParticipationStrategy to implement meetup application logic

### DIFF
--- a/src/main/java/com/flab/mealmate/domain/meetup/api/MeetupApi.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/api/MeetupApi.java
@@ -3,17 +3,22 @@ package com.flab.mealmate.domain.meetup.api;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.flab.mealmate.domain.meetup.application.MeetupApplyService;
 import com.flab.mealmate.domain.meetup.application.MeetupCreateService;
 import com.flab.mealmate.domain.meetup.application.MeetupSearchService;
+import com.flab.mealmate.domain.meetup.dto.MeetupApplyRequest;
 import com.flab.mealmate.domain.meetup.dto.MeetupCreateRequest;
 import com.flab.mealmate.domain.meetup.dto.MeetupCreateResponse;
+import com.flab.mealmate.domain.meetup.dto.MeetupApplyResponse;
 import com.flab.mealmate.domain.meetup.dto.MeetupSearchRequest;
 import com.flab.mealmate.domain.meetup.dto.MeetupSearchResponse;
+import com.flab.mealmate.global.config.security.AuthenticationUtils;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,6 +29,7 @@ public class MeetupApi {
 
 	private final MeetupCreateService meetupCreateService;
 	private final MeetupSearchService meetupSearchService;
+	private final MeetupApplyService meetupApplyService;
 
 	@PostMapping
 	public MeetupCreateResponse create(@RequestBody @Validated MeetupCreateRequest request) {
@@ -33,6 +39,11 @@ public class MeetupApi {
 	@GetMapping
 	public MeetupSearchResponse search(@ModelAttribute @Validated MeetupSearchRequest request) {
 		return meetupSearchService.search(request);
+	}
+
+	@PostMapping("/{meetupId}/applications")
+	public MeetupApplyResponse apply(@PathVariable Long meetupId, @RequestBody MeetupApplyRequest request) {
+		return meetupApplyService.apply(meetupId, request, AuthenticationUtils.getUserId());
 	}
 
 }

--- a/src/main/java/com/flab/mealmate/domain/meetup/application/MeetupApplyService.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/application/MeetupApplyService.java
@@ -1,0 +1,8 @@
+package com.flab.mealmate.domain.meetup.application;
+
+import com.flab.mealmate.domain.meetup.dto.MeetupApplyRequest;
+import com.flab.mealmate.domain.meetup.dto.MeetupApplyResponse;
+
+public interface MeetupApplyService {
+	MeetupApplyResponse apply(Long meetupId, MeetupApplyRequest request, Long userId);
+}

--- a/src/main/java/com/flab/mealmate/domain/meetup/application/MeetupApplyServiceV1.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/application/MeetupApplyServiceV1.java
@@ -1,0 +1,49 @@
+package com.flab.mealmate.domain.meetup.application;
+
+import static java.util.Optional.ofNullable;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.flab.mealmate.domain.meetup.application.participation.ParticipationStrategy;
+import com.flab.mealmate.domain.meetup.dao.MeetupRepository;
+import com.flab.mealmate.domain.meetup.dto.MeetupApplyRequest;
+import com.flab.mealmate.domain.meetup.dto.MeetupApplyResponse;
+import com.flab.mealmate.domain.meetup.entity.Meetup;
+import com.flab.mealmate.domain.meetup.entity.ParticipationType;
+import com.flab.mealmate.domain.meetup.mapper.MeetupApplyMapper;
+import com.flab.mealmate.global.error.exception.BusinessException;
+import com.flab.mealmate.global.error.exception.CustomIllegalArgumentException;
+import com.flab.mealmate.global.error.exception.ErrorCode;
+
+@Service
+@Transactional
+public class MeetupApplyServiceV1 implements MeetupApplyService {
+
+	private final Map<ParticipationType, ParticipationStrategy> strategyMap;
+	private final MeetupRepository meetupRepository;
+
+	public MeetupApplyServiceV1(List<ParticipationStrategy> strategies, MeetupRepository meetupRepository) {
+		this.meetupRepository = meetupRepository;
+		this.strategyMap = strategies.stream()
+			.collect(Collectors.toMap(ParticipationStrategy::getType, Function.identity()));
+	}
+
+	@Override
+	public MeetupApplyResponse apply(Long meetupId, MeetupApplyRequest request, Long userId) {
+		Meetup meetup = meetupRepository.findById(meetupId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.ERR_ENTITY_NOT_FOUND));
+
+		ParticipationStrategy strategy = ofNullable(strategyMap.get(meetup.getParticipationType()))
+			.orElseThrow(() -> new CustomIllegalArgumentException(ErrorCode.ERR_MEETUP_PARTICIPANT_003));
+
+		strategy.participate(meetup, request.getMessage(), userId);
+
+		return MeetupApplyMapper.toResponse(meetup);
+	}
+}

--- a/src/main/java/com/flab/mealmate/domain/meetup/application/MeetupApplyServiceV1.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/application/MeetupApplyServiceV1.java
@@ -42,7 +42,7 @@ public class MeetupApplyServiceV1 implements MeetupApplyService {
 		ParticipationStrategy strategy = ofNullable(strategyMap.get(meetup.getParticipationType()))
 			.orElseThrow(() -> new CustomIllegalArgumentException(ErrorCode.ERR_MEETUP_PARTICIPANT_003));
 
-		strategy.participate(meetup, request.getMessage(), userId);
+		strategy.participate(meetup, request.safeMessage(), userId);
 
 		return MeetupApplyMapper.toResponse(meetup);
 	}

--- a/src/main/java/com/flab/mealmate/domain/meetup/dto/MeetupApplyRequest.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/dto/MeetupApplyRequest.java
@@ -4,15 +4,21 @@ import java.util.Optional;
 
 import org.springframework.util.StringUtils;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class MeetupApplyRequest {
 
+	@JsonProperty
 	private String message;
+
 
 	public MeetupApplyRequest(String message) {
 		this.message = message;
 	}
 
-	public Optional<String> getMessage() {
+	@JsonIgnore
+	public Optional<String> safeMessage() {
 		return Optional.ofNullable(message).filter(StringUtils::hasText);
 	}
 }

--- a/src/main/java/com/flab/mealmate/domain/meetup/dto/MeetupApplyRequest.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/dto/MeetupApplyRequest.java
@@ -1,0 +1,18 @@
+package com.flab.mealmate.domain.meetup.dto;
+
+import java.util.Optional;
+
+import org.springframework.util.StringUtils;
+
+public class MeetupApplyRequest {
+
+	private String message;
+
+	public MeetupApplyRequest(String message) {
+		this.message = message;
+	}
+
+	public Optional<String> getMessage() {
+		return Optional.ofNullable(message).filter(StringUtils::hasText);
+	}
+}

--- a/src/main/java/com/flab/mealmate/domain/meetup/dto/MeetupApplyResponse.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/dto/MeetupApplyResponse.java
@@ -1,0 +1,13 @@
+package com.flab.mealmate.domain.meetup.dto;
+
+import lombok.Getter;
+
+@Getter
+public class MeetupApplyResponse {
+
+	private final String meetupId;
+
+	public MeetupApplyResponse(String meetupId) {
+		this.meetupId = meetupId;
+	}
+}

--- a/src/main/java/com/flab/mealmate/domain/meetup/mapper/MeetupApplyMapper.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/mapper/MeetupApplyMapper.java
@@ -1,0 +1,15 @@
+package com.flab.mealmate.domain.meetup.mapper;
+
+import com.flab.mealmate.domain.meetup.dto.MeetupApplyResponse;
+import com.flab.mealmate.domain.meetup.entity.Meetup;
+
+public class MeetupApplyMapper {
+
+	private MeetupApplyMapper() {
+		throw new UnsupportedOperationException();
+	}
+
+	public static MeetupApplyResponse toResponse(Meetup meetup) {
+		return new MeetupApplyResponse(String.valueOf(meetup.getId()));
+	}
+}

--- a/src/main/java/com/flab/mealmate/global/config/security/AuthenticationUtils.java
+++ b/src/main/java/com/flab/mealmate/global/config/security/AuthenticationUtils.java
@@ -1,0 +1,16 @@
+package com.flab.mealmate.global.config.security;
+
+import com.flab.mealmate.domain.model.User;
+
+/**
+ * 현재 인증된 사용자의 ID를 반환합니다.
+ * 현재는 시스템 사용자(User.createSystemUser())로 대체되어 있으며,
+ * 향후 SecurityContext 또는 인증 객체에서 실제 사용자 ID를 추출하도록 변경이 필요합니다.
+ * @return 사용자 ID (현재는 시스템 사용자 ID)
+ */
+public class AuthenticationUtils {
+
+	public static Long getUserId() {
+		return User.createSystemUser().getUserId();
+	}
+}

--- a/src/test/java/com/flab/mealmate/domain/meetup/api/MeetupApiTest.java
+++ b/src/test/java/com/flab/mealmate/domain/meetup/api/MeetupApiTest.java
@@ -6,10 +6,6 @@ import static com.flab.mealmate.global.util.JsonUtils.objectMapper;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static com.flab.mealmate.global.util.JsonUtils.objectMapper;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
@@ -32,8 +28,11 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 import com.epages.restdocs.apispec.SimpleType;
+import com.flab.mealmate.domain.meetup.application.MeetupApplyService;
 import com.flab.mealmate.domain.meetup.application.MeetupCreateService;
 import com.flab.mealmate.domain.meetup.application.MeetupSearchService;
+import com.flab.mealmate.domain.meetup.dto.MeetupApplyRequest;
+import com.flab.mealmate.domain.meetup.dto.MeetupApplyResponse;
 import com.flab.mealmate.domain.meetup.dto.MeetupCreateRequest;
 import com.flab.mealmate.domain.meetup.dto.MeetupCreateResponse;
 import com.flab.mealmate.domain.meetup.dto.MeetupSearchRequest;
@@ -56,6 +55,9 @@ class MeetupApiTest {
 
 	@MockitoBean
 	private MeetupSearchService meetupSearchService;
+
+	@MockitoBean
+	private MeetupApplyService meetupApplyService;
 
 	private final String TAG = "meetup";
 
@@ -141,6 +143,36 @@ class MeetupApiTest {
 				)
 				.build()
 			)
+			.andDo(print());
+	}
+
+	@Test
+	void apply() throws Exception {
+		// given
+		Long meetupId = 1L;
+		var response = new MeetupApplyResponse(String.valueOf(meetupId));
+		given(meetupApplyService.apply(any(Long.class), any(MeetupApplyRequest.class), any(Long.class)))
+			.willReturn(response);
+
+		ResultActions actions = mockMvc.perform(post("/meetups/{meetupId}/applications", meetupId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"message\":\"참여하고 싶어요!\"}")
+				.with(csrf().asHeader()))
+			.andExpect(status().isOk());
+
+		actions.andDo(ApiDocumentation.builder()
+				.tag(TAG)
+				.description("모임 참여 신청 API")
+				.pathParameters(
+					parameter("meetupId", SimpleType.NUMBER, "모임 ID")
+				)
+				.requestFields(
+					field("message", STRING, "참여 신청 메시지").optional()
+				)
+				.responseFields(
+					field("meetupId", STRING, "참여 신청된 모임 ID")
+				)
+				.build())
 			.andDo(print());
 	}
 }

--- a/src/test/java/com/flab/mealmate/domain/meetup/application/MeetupApplyServiceV1Test.java
+++ b/src/test/java/com/flab/mealmate/domain/meetup/application/MeetupApplyServiceV1Test.java
@@ -1,0 +1,84 @@
+package com.flab.mealmate.domain.meetup.application;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.flab.mealmate.domain.meetup.application.participation.ParticipationStrategy;
+import com.flab.mealmate.domain.meetup.dao.MeetupRepository;
+import com.flab.mealmate.domain.meetup.dto.MeetupApplyRequest;
+import com.flab.mealmate.domain.meetup.entity.Meetup;
+import com.flab.mealmate.domain.meetup.entity.MeetupMock;
+import com.flab.mealmate.domain.meetup.entity.ParticipationType;
+import com.flab.mealmate.global.error.exception.BusinessException;
+
+@ExtendWith(MockitoExtension.class)
+class MeetupApplyServiceV1Test {
+
+	@Mock
+	private MeetupRepository meetupRepository;
+
+	@Mock
+	private ParticipationStrategy autoParticipationStrategy;
+	@Mock
+	private ParticipationStrategy approvalParticipationStrategy;
+
+	private MeetupApplyServiceV1 service;
+
+	private MeetupApplyRequest applyRequest;
+
+	@BeforeEach
+	void setUp() {
+		given(autoParticipationStrategy.getType()).willReturn(ParticipationType.AUTO);
+		given(approvalParticipationStrategy.getType()).willReturn(ParticipationType.APPROVAL);
+
+		service = new MeetupApplyServiceV1(
+			List.of(autoParticipationStrategy, approvalParticipationStrategy),
+			meetupRepository
+		);
+
+		applyRequest = new MeetupApplyRequest("신청합니다.");
+	}
+
+
+	@Test
+	void shouldInvokeParticipationStrategy() {
+		// given
+		Long meetupId = 1L;
+		Long userId = 42L;
+		Meetup meetup = MeetupMock.createAuto(3, 5);
+
+		given(meetupRepository.findById(anyLong())).willReturn(Optional.of(meetup));
+		service.apply(meetupId, applyRequest, userId);
+
+		verify(autoParticipationStrategy, times(1))
+			.participate(
+				any(Meetup.class),
+				any(Optional.class),
+				anyLong()
+			);
+	}
+	@Test
+	void throwsExceptionWhenMeetupNotFound() {
+		Long meetupId = 999L;
+		given(meetupRepository.findById(meetupId)).willReturn(Optional.empty());
+
+		// when & then
+		assertThrows(BusinessException.class, () -> {
+			service.apply(meetupId, applyRequest, 1L);
+		});
+	}
+
+}


### PR DESCRIPTION
## ✅ 작업 개요
기존의 `ParticipationStrategy` 인터페이스를 기반으로  
모임 참여 신청 로직 (`MeetupApplyServiceV1`) 을 구현했습니다.


## ✅ 주요 변경 사항

- [X] `MeetupApplyServiceV1` 클래스 구현
  - 전략 패턴 기반 분기 처리
  - `Map<ParticipationType, ParticipationStrategy>`로 전략 주입
- [X] `MeetupApplyMapper`: domain → response 변환 로직 정의
- [X] 예외 처리
  - 존재하지 않는 meetup ID 요청 시 `BusinessException` 발생
  - 매칭되지 않는 ParticipationType 사용 시 `CustomIllegalArgumentException` 발생

