### PR TITLE
feat(meetup): add participation apply endpoint

### DIFF
--- a/src/main/java/com/flab/mealmate/domain/meetup/api/MeetupApi.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/api/MeetupApi.java
@@ -3,17 +3,22 @@ package com.flab.mealmate.domain.meetup.api;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.flab.mealmate.domain.meetup.application.MeetupApplyService;
 import com.flab.mealmate.domain.meetup.application.MeetupCreateService;
 import com.flab.mealmate.domain.meetup.application.MeetupSearchService;
+import com.flab.mealmate.domain.meetup.dto.MeetupApplyRequest;
 import com.flab.mealmate.domain.meetup.dto.MeetupCreateRequest;
 import com.flab.mealmate.domain.meetup.dto.MeetupCreateResponse;
+import com.flab.mealmate.domain.meetup.dto.MeetupApplyResponse;
 import com.flab.mealmate.domain.meetup.dto.MeetupSearchRequest;
 import com.flab.mealmate.domain.meetup.dto.MeetupSearchResponse;
+import com.flab.mealmate.global.config.security.AuthenticationUtils;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,6 +29,7 @@ public class MeetupApi {
 
 	private final MeetupCreateService meetupCreateService;
 	private final MeetupSearchService meetupSearchService;
+	private final MeetupApplyService meetupApplyService;
 
 	@PostMapping
 	public MeetupCreateResponse create(@RequestBody @Validated MeetupCreateRequest request) {
@@ -33,6 +39,11 @@ public class MeetupApi {
 	@GetMapping
 	public MeetupSearchResponse search(@ModelAttribute @Validated MeetupSearchRequest request) {
 		return meetupSearchService.search(request);
+	}
+
+	@PostMapping("/{meetupId}/applications")
+	public MeetupApplyResponse apply(@PathVariable Long meetupId, @RequestBody MeetupApplyRequest request) {
+		return meetupApplyService.apply(meetupId, request, AuthenticationUtils.getUserId());
 	}
 
 }

--- a/src/main/java/com/flab/mealmate/domain/meetup/application/MeetupApplyServiceV1.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/application/MeetupApplyServiceV1.java
@@ -42,7 +42,7 @@ public class MeetupApplyServiceV1 implements MeetupApplyService {
 		ParticipationStrategy strategy = ofNullable(strategyMap.get(meetup.getParticipationType()))
 			.orElseThrow(() -> new CustomIllegalArgumentException(ErrorCode.ERR_MEETUP_PARTICIPANT_003));
 
-		strategy.participate(meetup, request.getMessage(), userId);
+		strategy.participate(meetup, request.safeMessage(), userId);
 
 		return MeetupApplyMapper.toResponse(meetup);
 	}

--- a/src/main/java/com/flab/mealmate/domain/meetup/dto/MeetupApplyRequest.java
+++ b/src/main/java/com/flab/mealmate/domain/meetup/dto/MeetupApplyRequest.java
@@ -4,15 +4,21 @@ import java.util.Optional;
 
 import org.springframework.util.StringUtils;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class MeetupApplyRequest {
 
+	@JsonProperty
 	private String message;
+
 
 	public MeetupApplyRequest(String message) {
 		this.message = message;
 	}
 
-	public Optional<String> getMessage() {
+	@JsonIgnore
+	public Optional<String> safeMessage() {
 		return Optional.ofNullable(message).filter(StringUtils::hasText);
 	}
 }

--- a/src/main/java/com/flab/mealmate/global/config/security/AuthenticationUtils.java
+++ b/src/main/java/com/flab/mealmate/global/config/security/AuthenticationUtils.java
@@ -1,0 +1,16 @@
+package com.flab.mealmate.global.config.security;
+
+import com.flab.mealmate.domain.model.User;
+
+/**
+ * 현재 인증된 사용자의 ID를 반환합니다.
+ * 현재는 시스템 사용자(User.createSystemUser())로 대체되어 있으며,
+ * 향후 SecurityContext 또는 인증 객체에서 실제 사용자 ID를 추출하도록 변경이 필요합니다.
+ * @return 사용자 ID (현재는 시스템 사용자 ID)
+ */
+public class AuthenticationUtils {
+
+	public static Long getUserId() {
+		return User.createSystemUser().getUserId();
+	}
+}

--- a/src/test/java/com/flab/mealmate/domain/meetup/api/MeetupApiTest.java
+++ b/src/test/java/com/flab/mealmate/domain/meetup/api/MeetupApiTest.java
@@ -6,10 +6,6 @@ import static com.flab.mealmate.global.util.JsonUtils.objectMapper;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static com.flab.mealmate.global.util.JsonUtils.objectMapper;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
@@ -32,8 +28,11 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 import com.epages.restdocs.apispec.SimpleType;
+import com.flab.mealmate.domain.meetup.application.MeetupApplyService;
 import com.flab.mealmate.domain.meetup.application.MeetupCreateService;
 import com.flab.mealmate.domain.meetup.application.MeetupSearchService;
+import com.flab.mealmate.domain.meetup.dto.MeetupApplyRequest;
+import com.flab.mealmate.domain.meetup.dto.MeetupApplyResponse;
 import com.flab.mealmate.domain.meetup.dto.MeetupCreateRequest;
 import com.flab.mealmate.domain.meetup.dto.MeetupCreateResponse;
 import com.flab.mealmate.domain.meetup.dto.MeetupSearchRequest;
@@ -56,6 +55,9 @@ class MeetupApiTest {
 
 	@MockitoBean
 	private MeetupSearchService meetupSearchService;
+
+	@MockitoBean
+	private MeetupApplyService meetupApplyService;
 
 	private final String TAG = "meetup";
 
@@ -141,6 +143,36 @@ class MeetupApiTest {
 				)
 				.build()
 			)
+			.andDo(print());
+	}
+
+	@Test
+	void apply() throws Exception {
+		// given
+		Long meetupId = 1L;
+		var response = new MeetupApplyResponse(String.valueOf(meetupId));
+		given(meetupApplyService.apply(any(Long.class), any(MeetupApplyRequest.class), any(Long.class)))
+			.willReturn(response);
+
+		ResultActions actions = mockMvc.perform(post("/meetups/{meetupId}/applications", meetupId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"message\":\"참여하고 싶어요!\"}")
+				.with(csrf().asHeader()))
+			.andExpect(status().isOk());
+
+		actions.andDo(ApiDocumentation.builder()
+				.tag(TAG)
+				.description("모임 참여 신청 API")
+				.pathParameters(
+					parameter("meetupId", SimpleType.NUMBER, "모임 ID")
+				)
+				.requestFields(
+					field("message", STRING, "참여 신청 메시지").optional()
+				)
+				.responseFields(
+					field("meetupId", STRING, "참여 신청된 모임 ID")
+				)
+				.build())
 			.andDo(print());
 	}
 }


### PR DESCRIPTION
## ✅ 작업 개요

기존 `MeetupApi` 컨트롤러에 모임 참여 신청 엔드포인트를 추가하였습니다.  
사용자는 특정 모임에 대해 참여 신청을 하고, 선택적으로 메시지를 함께 전달할 수 있습니다.

## ✅ 주요 변경사항
- [X] `POST /meetups/{meetupId}/applications` 엔드포인트 추가
  - 참여 방식에 따라 전략을 적용하는 `MeetupApplyServiceV1` 연동
- [X]  인증된 사용자 ID 추출을 위한 `AuthenticationUtils` 적용
  - 현재 회원 서비스 및 인증 로직 이 없는 관계로 System User로 고정
- [X] 컨트롤러 테스트 및 API 명세 문서(RestDocs) 작성
